### PR TITLE
feat(frontend): Set status node color based on status

### DIFF
--- a/frontend/src/components/create-node-dialog.tsx
+++ b/frontend/src/components/create-node-dialog.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useShallow } from "zustand/react/shallow";
-import { statusNodeIconMap, statusNodeIconOptions } from "./status-icons";
+import { statusNodeIconMap, statusNodeIconOptions } from "./state-colors-icons";
 import { Button } from "./ui/button";
 import {
   Form,

--- a/frontend/src/components/edit-node-dialog.tsx
+++ b/frontend/src/components/edit-node-dialog.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useShallow } from "zustand/react/shallow";
-import { statusNodeIconMap, statusNodeIconOptions } from "./status-icons";
+import { statusNodeIconMap, statusNodeIconOptions } from "./state-colors-icons";
 import { Button } from "./ui/button";
 import {
   Form,

--- a/frontend/src/components/git-revision.tsx
+++ b/frontend/src/components/git-revision.tsx
@@ -33,9 +33,9 @@ export const GitRevision = ({
 
   return (
     <div className={cn("flex flex-1 items-center text-muted-foreground")}>
-      <GitBranch size={20} />
+      <GitBranch size={16} />
 
-      <span className="flex-1 font-mono px-3 py-1 truncate align-middle">
+      <span className="flex-1 font-mono px-3  truncate align-middle">
         {revision}
       </span>
       {onClickPinRevision && (
@@ -48,9 +48,9 @@ export const GitRevision = ({
           <Button
             ref={ref}
             variant="ghost"
-            className={cn("nodrag size-6 p-1 cursor-pointer")}
+            className={cn("nodrag size-6 cursor-pointer")}
           >
-            <Pin size={20} />
+            <Pin size={16} />
           </Button>
         </DynamicTooltip>
       )}

--- a/frontend/src/components/icon-selector.tsx
+++ b/frontend/src/components/icon-selector.tsx
@@ -5,7 +5,7 @@ import {
   SelectTriggerIcon,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { IconMap, IconOptions } from "./status-icons";
+import type { IconMap, IconOptions } from "./state-colors-icons";
 
 // Define the props interface for IconSelector
 interface IconSelectorProps<T extends string = string> {

--- a/frontend/src/components/nodes.tsx
+++ b/frontend/src/components/nodes.tsx
@@ -7,6 +7,7 @@ import {
   NodeHeaderMenuAction,
   NodeHeaderTitle,
 } from "@/components/node-header";
+import { cn } from "@/lib/utils";
 import { useStore } from "@/store";
 import {
   type ActionNode as ActionNodeType,
@@ -26,7 +27,11 @@ import { memo, useCallback, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { GitRevision } from "./git-revision";
 import { IconSelector } from "./icon-selector";
-import { statusNodeIconMap, statusNodeIconOptions } from "./status-icons";
+import {
+  statusNodeIconMap,
+  statusNodeIconOptions,
+  statusNodeStateColorsMap,
+} from "./state-colors-icons";
 import { DropdownMenuContent, DropdownMenuItem } from "./ui/dropdown-menu";
 
 const AppNodeHeaderMenuAction = ({ id, type, data }: EditAppNodeData) => {
@@ -97,10 +102,22 @@ export const StatusNode = memo(
     const { addGitRevision } = useStore(useShallow(selector));
     const { updateNodeData } = useReactFlow();
     return (
-      <BaseNode selected={selected} className="px-3 py-2 max-w-md">
-        <NodeHeader className="-mx-3 -mt-2 border-b">
+      <BaseNode
+        selected={selected}
+        className={cn(
+          "px-2 pt-2 pb-0 max-w-md",
+          statusNodeStateColorsMap[data.state].bg,
+          statusNodeStateColorsMap[data.state].border,
+        )}
+      >
+        <NodeHeader
+          className={cn(
+            "-mx-2 -mt-2 px-2 border-b",
+            statusNodeStateColorsMap[data.state].border,
+          )}
+        >
           <NodeHeaderIcon>
-            <ChartLine />
+            <ChartLine size="16" />
           </NodeHeaderIcon>
           <NodeHeaderTitle>{data.title}</NodeHeaderTitle>
           <NodeHeaderActions>
@@ -119,9 +136,16 @@ export const StatusNode = memo(
         {data.hasTargetHandle && (
           <BaseHandle id="target-1" type="target" position={Position.Left} />
         )}
-        {data.description && <div className="mt-2">{data.description}</div>}
+        {data.description && <div className="py-2">{data.description}</div>}
         {data.git.rev !== "" && (
-          <NodeHeader className="-mx-3 -mb-2 mt-2 border-t">
+          <NodeHeader
+            className={cn(
+              "-mx-2 px-2",
+              data.description
+                ? cn("border-t", statusNodeStateColorsMap[data.state].border)
+                : "",
+            )}
+          >
             <GitRevision
               revision={data.git.rev}
               onClickPinRevision={addGitRevision}

--- a/frontend/src/components/nodes.tsx
+++ b/frontend/src/components/nodes.tsx
@@ -78,10 +78,12 @@ const selector = (s: AppState) => ({
 export const ActionNode = memo(
   ({ id, data, selected }: NodeProps<ActionNodeType>) => {
     return (
-      <BaseNode selected={selected} className="px-3 py-2 max-w-md">
-        <NodeHeader className="-mx-3 -mt-2 border-b">
+      <BaseNode selected={selected} className="px-2 pt-2 pb-0 max-w-md">
+        <NodeHeader
+          className={cn("-mx-2 -mt-2 px-2", data.description && "border-b")}
+        >
           <NodeHeaderIcon>
-            <Rocket />
+            <Rocket size="16" />
           </NodeHeaderIcon>
           <NodeHeaderTitle>{data.title}</NodeHeaderTitle>
           <NodeHeaderActions>
@@ -89,8 +91,7 @@ export const ActionNode = memo(
           </NodeHeaderActions>
         </NodeHeader>
         <BaseHandle id="target-1" type="target" position={Position.Left} />
-        {data.description && <div className="mt-2">{data.description}</div>}
-
+        {data.description && <div className="py-2">{data.description}</div>}
         <BaseHandle id="source-1" type="source" position={Position.Right} />
       </BaseNode>
     );
@@ -112,8 +113,10 @@ export const StatusNode = memo(
       >
         <NodeHeader
           className={cn(
-            "-mx-2 -mt-2 px-2 border-b",
-            statusNodeStateColorsMap[data.state].border,
+            "-mx-2 -mt-2 px-2",
+            data.description || data.git.rev
+              ? cn("border-b", statusNodeStateColorsMap[data.state].border)
+              : "",
           )}
         >
           <NodeHeaderIcon>

--- a/frontend/src/components/state-colors-icons.tsx
+++ b/frontend/src/components/state-colors-icons.tsx
@@ -1,5 +1,5 @@
+import type { StatusNodeState } from "@/types/nodes";
 import { Ban, CircleCheck, CircleQuestionMark, TrendingUp } from "lucide-react";
-import type { StatusNodeState } from "../types/nodes";
 
 // A generic string key maps to a ReactNode (JSX.Element), these are the icons shown for the individual elements
 export type IconMap<T extends string = string> = Record<T, React.ReactNode>;
@@ -19,12 +19,39 @@ export const statusNodeIconOptions: IconOptions<StatusNodeState> = [
   { value: "progress", label: "Progress" },
   { value: "fail", label: "Fail" },
   { value: "success", label: "Success" },
-];
+] as const;
 
 // Map status note states to icons
 export const statusNodeIconMap: IconMap<StatusNodeState> = {
-  unknown: <CircleQuestionMark size={16} className="stroke-gray-400" />,
+  unknown: <CircleQuestionMark size={16} className="stroke-zinc-400" />,
   progress: <TrendingUp size={16} className="stroke-amber-400" />,
-  fail: <Ban size={16} className="stroke-red-500" />,
-  success: <CircleCheck size={16} className="stroke-green-500" />,
-};
+  fail: <Ban size={16} className="stroke-red-400" />,
+  success: <CircleCheck size={16} className="stroke-emerald-400" />,
+} as const;
+
+interface StatusNodeStateColors {
+  bg: string;
+  border: string;
+}
+
+export const statusNodeStateColorsMap: Record<
+  StatusNodeState,
+  StatusNodeStateColors
+> = {
+  unknown: {
+    bg: "bg-zinc-100 dark:bg-zinc-700",
+    border: "border-zinc-300 dark:border-zinc-500",
+  },
+  progress: {
+    bg: "bg-amber-100 dark:bg-amber-950",
+    border: "border-amber-300 dark:border-amber-800",
+  },
+  fail: {
+    bg: "bg-red-100 dark:bg-red-950",
+    border: "border-red-300 dark:border-red-800",
+  },
+  success: {
+    bg: "bg-emerald-100 dark:bg-emerald-950",
+    border: "border-emerald-300 dark:border-emerald-800",
+  },
+} as const;


### PR DESCRIPTION
This PR changes the background and border colors for status nodes based on their states.

See the colors in light and dark mode below:

Dark mode             |  Light mode
:-------------------------:|:-------------------------:
<img width="449" height="882" alt="Screenshot 2025-07-11 at 15 08 07" src="https://github.com/user-attachments/assets/039b755b-33cb-47c5-85a9-8473f3e0ab90" /> | <img width="423" height="852" alt="Screenshot 2025-07-11 at 14 59 30" src="https://github.com/user-attachments/assets/01ca50d6-a78a-4574-8c72-14c41a08333c" />


Also the handling of borders in nodes is fixed:

Before | After
:---:|:--:
<img width="595" height="849" alt="Screenshot 2025-07-11 at 15 45 17" src="https://github.com/user-attachments/assets/ab9a8fa4-8dbb-42aa-acd3-a75b370ac184" /> | <img width="506" height="747" alt="Screenshot 2025-07-11 at 15 43 36" src="https://github.com/user-attachments/assets/e3874a9a-8fdf-4521-95b7-220fbad08bdc" />

