### PR TITLE
fix(edge-type): Use edge type default instead of bezier

### DIFF
--- a/frontend/src/components/app-menubar.tsx
+++ b/frontend/src/components/app-menubar.tsx
@@ -46,7 +46,7 @@ const flowSelector = (s: AppState) => ({
   closeCurrentFlow: s.closeCurrentFlow,
   saveCurrentFlow: s.saveCurrentFlow,
   currentEdgeType:
-    s.edges.length > 0 && s.edges[0].type ? s.edges[0].type : "bezier",
+    s.edges.length > 0 && s.edges[0].type ? s.edges[0].type : "default",
   setEdgeType: s.setEdgeType,
 });
 

--- a/frontend/src/types/edge.ts
+++ b/frontend/src/types/edge.ts
@@ -1,7 +1,7 @@
-export type EdgeType = "straight" | "step" | "smoothstep" | "bezier";
+export type EdgeType = "straight" | "step" | "smoothstep" | "default";
 export const edgeTypes: EdgeType[] = [
   "straight",
   "step",
   "smoothstep",
-  "bezier",
+  "default",
 ] as const;


### PR DESCRIPTION
By default the `edgeTypes` prop of the `ReactFlow` component is initialized with the following:

``` ts
{
  default: BezierEdge,
  straight: StraightEdge,
  step: StepEdge,
  smoothstep: SmoothStepEdge,
  simplebezier: SimpleBezier
}
```

Thus edge type default maps to bezier, so just use default.


Closes #9 