### PR TITLE
fix(async-combobox): Set clear button type as "button"

### DIFF
--- a/frontend/src/components/async-combobox.tsx
+++ b/frontend/src/components/async-combobox.tsx
@@ -123,6 +123,7 @@ export const AsyncCombobox = <ItemType,>({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          type="button"
           variant="outline"
           role="combobox"
           aria-expanded={open}
@@ -136,7 +137,7 @@ export const AsyncCombobox = <ItemType,>({
         </Button>
       </PopoverTrigger>
       {value && (
-        <Button variant="outline" onClick={handleClear}>
+        <Button variant="outline" type="button" onClick={handleClear}>
           Clear
         </Button>
       )}


### PR DESCRIPTION
When having an invalid form and pressing enter, the input value of the `AsyncCombobox` was cleared. This happened by calling `onClick` handler for the clear button `handleClear` of the `AsyncCombobox`.

But in HTML, any `<button>` inside a `<form>` defaults to `type="submit"` unless specified otherwise. So when pressing "Enter" while focused on an input field, it triggers the first button with type="submit" in the form, or submits the form itself — which called the clear button's `onClick` handler.

Closes #49 