### PR TITLE
Clean-up node dialog state handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,7 +104,6 @@ export default function App() {
   useHotkeys(
     keybindings.open.keys,
     () => {
-      void saveCurrentFlow();
       setIsFlowsDialogOpen(true);
     },
     {

--- a/frontend/src/components/app-menubar.tsx
+++ b/frontend/src/components/app-menubar.tsx
@@ -27,6 +27,7 @@ import {
 } from "@xyflow/react";
 import { Workflow } from "lucide-react";
 import { useTheme } from "next-themes";
+import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
 
 interface AppMenubarProps {
@@ -151,8 +152,11 @@ export const AppMenubar = ({ reactflowRef }: AppMenubarProps) => {
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            onSelect={closeCurrentFlow}
+            onSelect={() => {
+              saveCurrentFlow().then(closeCurrentFlow, () => {
+                toast.error("Flow was not closed due to save error");
+              });
+            }}
           >
             Close
           </MenubarItem>

--- a/frontend/src/components/create-node-dialog.tsx
+++ b/frontend/src/components/create-node-dialog.tsx
@@ -92,10 +92,20 @@ export const CreateNodeDialog = () => {
     <Dialog
       open={isOpen}
       onOpenChange={(open) => {
-        if (!open && nodes.length == 0) {
-          return;
+        if (!open) {
+          if (nodes.length === 0) {
+            // If there are no nodes yet, one needs to be created first and the dialog cannot be closed yet
+            return;
+          }
+          // When closing the dialog, set pending node data to null.
+          // pendingNodeData is stored persistently (to-reopen the create node dialog if no nodes
+          // are created). If the data would not be reset here, a potential reload would reopen the
+          // dialog, as pendingNodeData still has a value. This avoids that a the dialog is automatically
+          // opened after a reload
+          setPendingNode(null);
+          // At this point it is sufficient to set the pending node data to null, the useEffect in this
+          // component will close it for us
         }
-        setIsOpen(open);
       }}
     >
       <DialogContent

--- a/frontend/src/components/edit-node-dialog.tsx
+++ b/frontend/src/components/edit-node-dialog.tsx
@@ -58,8 +58,9 @@ export const EditNodeDialog = () => {
       onOpenChange={(open) => {
         if (!open) {
           setCurrentEditNodeData(null);
+          // At this point it is sufficient to set the current edit node data to null, the useEffect in this
+          // component will close it for us and also re-open if some component sets it at some point
         }
-        setIsOpen(open);
       }}
     >
       <DialogContent className="md:max-w-[700px]">

--- a/frontend/src/components/flows-dialog.tsx
+++ b/frontend/src/components/flows-dialog.tsx
@@ -64,6 +64,7 @@ const selector = (s: AppState) => ({
   deleteFlow: s.deleteFlow,
   loadFlow: s.loadFlow,
   setPendingNode: s.setPendingNodeData,
+  saveCurrentFlow: s.saveCurrentFlow,
 });
 
 export const FlowsDialog: React.FC<FlowsDialogProps> = ({
@@ -85,6 +86,7 @@ export const FlowsDialog: React.FC<FlowsDialogProps> = ({
     createFlow,
     deleteFlow,
     setPendingNode,
+    saveCurrentFlow,
   } = useStore(useShallow(selector));
   const [isFlowsLoading, setIsFlowsLoading] = useState(false);
 
@@ -111,6 +113,15 @@ export const FlowsDialog: React.FC<FlowsDialogProps> = ({
       setIsOpen(false);
     }
   }, [setIsOpen, currentFlow]);
+
+  useEffect(() => {
+    if (isOpen) {
+      saveCurrentFlow().catch(() => {
+        // Close the dialog again, otherwise the dialog can be used to delete the currently opened flow
+        setIsOpen(false);
+      });
+    }
+  }, [isOpen, setIsOpen, saveCurrentFlow]);
 
   const [selectedFlow, setSelectedFlow] = useState<string | null>(null);
   const [filterTerm, setFilterTerm] = useState<string>("");

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -14,12 +14,13 @@ import { isStatusNode, type AppNode, type AppNodeType } from "./types/nodes";
 import { type AppState, type UiState } from "./types/state";
 
 /**
- * Whether the state before a set of {@link NodeChange}s should be added to the undo stack
+ * Whether the state before a set of {@link NodeChange}s should be added to the
+ * {@link AppState.undoStack}
  * @param changes - Array of changes passed to {@link AppState.onNodesChange}
  * @param nodes - Nodes existing before the changes are applied
  * @returns Whether the changes should be added to the undo stack
  */
-const shouldObserveNodeChangesForUndo = (
+const areNodeChangesNotableForUndoStack = (
   changes: NodeChange<AppNode>[],
   nodes: AppNode[],
 ) => {
@@ -37,7 +38,33 @@ const shouldObserveNodeChangesForUndo = (
   });
 };
 
-const shouldSaveEdgeChanges = (
+/**
+ * Whether the {@link NodeChange}s should set {@link AppState.hasUnsavedChanges}
+ * @param changes - Array of changes passed to {@link AppState.onEdgesChange}
+ * @returns Whether the {@link NodeChange}s should set {@link AppState.hasUnsavedChanges}
+ */
+const areNodeChangesNotableForHasUnsavedChanges = (
+  changes: NodeChange<AppNode>[],
+) => {
+  return changes.some((change) => {
+    return (
+      change.type === "remove" ||
+      change.type === "add" ||
+      change.type === "replace" ||
+      change.type === "position"
+    );
+  });
+};
+
+/**
+ * Whether the state before a state before a set of {@link EdgeChange}ss should be added
+ * to the {@link AppState.undoStack} and should set {@link AppState.hasUnsavedChanges}
+ * @param changes - Array of changes passed to {@link AppState.onEdgesChange}
+ * @param nodes - Nodes existing before the changes are applied
+ * @returns Whether the state before a state before a set of {@link EdgeChange}ss should be added
+ * to the {@link AppState.undoStack} and should set {@link AppState.hasUnsavedChanges}
+ */
+const areEdgeChangesNotable = (
   changes: EdgeChange<Edge>[],
   nodes: AppNode[],
 ) => {
@@ -218,10 +245,11 @@ export const useStore = create<AppState>()(
         });
       },
       onNodesChange: (changes) => {
-        const { nodes, undoInProgress, pushToUndoStack } = get();
+        const { nodes, undoInProgress, pushToUndoStack, hasUnsavedChanges } =
+          get();
         if (
           !undoInProgress &&
-          shouldObserveNodeChangesForUndo(changes, nodes)
+          areNodeChangesNotableForUndoStack(changes, nodes)
         ) {
           pushToUndoStack();
         }
@@ -229,12 +257,15 @@ export const useStore = create<AppState>()(
 
         set({
           nodes: newNodes,
-          hasUnsavedChanges: true,
+          hasUnsavedChanges:
+            hasUnsavedChanges ||
+            areNodeChangesNotableForHasUnsavedChanges(changes),
         });
       },
       onEdgesChange: (changes) => {
-        const { edges, nodes, undoStack } = get();
-        if (shouldSaveEdgeChanges(changes, nodes)) {
+        const { edges, nodes, undoStack, hasUnsavedChanges } = get();
+        const notableChanges = areEdgeChangesNotable(changes, nodes);
+        if (notableChanges) {
           set({
             undoStack: [...undoStack, { nodes, edges }],
             redoStack: [],
@@ -243,7 +274,7 @@ export const useStore = create<AppState>()(
 
         set({
           edges: applyEdgeChanges(changes, edges),
-          hasUnsavedChanges: true,
+          hasUnsavedChanges: hasUnsavedChanges || notableChanges,
         });
       },
       onConnect: (connection) => {

--- a/frontend/src/types/state.ts
+++ b/frontend/src/types/state.ts
@@ -103,7 +103,7 @@ export interface AppState {
   /** Save the {@link nodes} and {@link edges} of the {@link currentFlow} to the server */
   saveCurrentFlow: () => Promise<void>;
   /** Save the {@link currentFlow} to the server and close it the current flow */
-  closeCurrentFlow: () => Promise<void>;
+  closeCurrentFlow: () => void;
   /** ReactFlow onNodesChange callback */
   onNodesChange: OnNodesChange<AppNode>;
   /** ReactFlow onEdgesChange callback */


### PR DESCRIPTION
Open / close is now only managed through useEffect, the dialog is opened if pendingNode or currentEditNode is set and closed if the parameter is set to null.

There was a bug in the CreateNodeDialog the the pendingNodeData was not set to null on closing. This led to the behavior that the dialog was closed, but on a reload it would be opened again.

Also 4df39d3 fixes some behavior around node closing and saving and 27371e8 fixes handling of the `hasUnsavedChanges` flag in the store.

Related #29 