### PR TITLE
feat: Simplify node layout

### DIFF
--- a/frontend/src/components/base-node.tsx
+++ b/frontend/src/components/base-node.tsx
@@ -32,7 +32,8 @@ interface NodeSectionProps {
 export const NodeContent = ({
   children,
   ...props
-}: NodeSectionProps & HTMLAttributes<HTMLDivElement>) => {
+}: NodeSectionProps &
+  HTMLAttributes<HTMLDivElement>): React.ReactElement | null => {
   if (!children) return null;
   return <div {...props}>{children}</div>;
 };
@@ -45,7 +46,8 @@ export const NodeSection = ({
   children,
   className,
   ...props
-}: NodeSectionProps & HTMLAttributes<HTMLDivElement>) => {
+}: NodeSectionProps &
+  HTMLAttributes<HTMLDivElement>): React.ReactElement | null => {
   if (!children) return null;
   return (
     <div className={cn("px-3 py-2", className)} {...props}>

--- a/frontend/src/components/base-node.tsx
+++ b/frontend/src/components/base-node.tsx
@@ -9,7 +9,7 @@ export const BaseNode = forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative rounded-md border bg-card p-5 text-card-foreground",
+      "relative rounded-md border bg-card text-card-foreground",
       className,
       selected ? "border-muted-foreground shadow-lg" : "",
       "hover:ring-1",
@@ -20,3 +20,38 @@ export const BaseNode = forwardRef<
 ));
 
 BaseNode.displayName = "BaseNode";
+
+interface NodeSectionProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper around {@link NodeSection} components, used to apply
+ * common classes (e.g. divide-y)
+ */
+export const NodeContent = ({
+  children,
+  ...props
+}: NodeSectionProps & HTMLAttributes<HTMLDivElement>) => {
+  if (!children) return null;
+  return <div {...props}>{children}</div>;
+};
+NodeContent.displayName = "NodeContent";
+
+/**
+ * General node segment with meaningful padding
+ */
+export const NodeSection = ({
+  children,
+  className,
+  ...props
+}: NodeSectionProps & HTMLAttributes<HTMLDivElement>) => {
+  if (!children) return null;
+  return (
+    <div className={cn("px-3 py-2", className)} {...props}>
+      {children}
+    </div>
+  );
+};
+
+NodeSection.displayName = "NodeSection";

--- a/frontend/src/components/nodes.tsx
+++ b/frontend/src/components/nodes.tsx
@@ -1,5 +1,5 @@
 import { BaseHandle } from "@/components/base-handle";
-import { BaseNode } from "@/components/base-node";
+import { BaseNode, NodeContent, NodeSection } from "@/components/base-node";
 import {
   NodeHeader,
   NodeHeaderActions,
@@ -81,28 +81,34 @@ const selector = (s: AppState) => ({
   addGitRevision: s.addGitRevision,
 });
 
+const commonNodeClasses = "w-xs" as const;
+
 export const ActionNode = memo(
   ({ id, data, selected }: NodeProps<ActionNodeType>) => {
     return (
-      <BaseNode selected={selected} className="px-2 pt-2 pb-0 max-w-md">
-        <NodeHeader
-          className={cn("-mx-2 -mt-2 px-2", data.description && "border-b")}
-        >
-          <NodeHeaderIcon>
-            <Rocket size="16" />
-          </NodeHeaderIcon>
-          <NodeHeaderTitle>{data.title}</NodeHeaderTitle>
-          <NodeHeaderActions>
-            <AppNodeHeaderMenuAction id={id} type={"actionNode"} data={data} />
-          </NodeHeaderActions>
-        </NodeHeader>
+      <BaseNode selected={selected} className={commonNodeClasses}>
+        <NodeContent className="divide-y">
+          <NodeHeader>
+            <NodeHeaderIcon>
+              <Rocket size="16" />
+            </NodeHeaderIcon>
+            <NodeHeaderTitle>{data.title}</NodeHeaderTitle>
+            <NodeHeaderActions>
+              <AppNodeHeaderMenuAction
+                id={id}
+                type={"actionNode"}
+                data={data}
+              />
+            </NodeHeaderActions>
+          </NodeHeader>
+          <NodeSection children={data.description}></NodeSection>
+        </NodeContent>
         <BaseHandle
           id="target-1"
           type="target"
           position={Position.Left}
           // isConnectable={false}
         />
-        {data.description && <div className="py-2">{data.description}</div>}
         <BaseHandle id="source-1" type="source" position={Position.Right} />
       </BaseNode>
     );
@@ -117,40 +123,48 @@ export const StatusNode = memo(
       <BaseNode
         selected={selected}
         className={cn(
-          "px-2 pt-2 pb-0 max-w-md",
+          commonNodeClasses,
           statusNodeStateClasses[data.state].bg,
           statusNodeStateClasses[data.state].border,
         )}
       >
-        <NodeHeader
-          className={cn(
-            "-mx-2 -mt-2 px-2",
-            data.description || data.git
-              ? cn("border-b", statusNodeStateClasses[data.state].border)
-              : "",
-          )}
+        <NodeContent
+          className={cn("divide-y", statusNodeStateClasses[data.state].divide)}
         >
-          <NodeHeaderIcon>
-            <ChartLine size="16" />
-          </NodeHeaderIcon>
-          <NodeHeaderTitle>{data.title}</NodeHeaderTitle>
-          <NodeHeaderActions>
-            <IconSelect<StatusNodeState>
-              selectedIcon={data.state}
-              onSelectChange={(newState) => {
-                updateNodeData(id, { state: newState });
-              }}
-              optionsAndIcons={statusNodeStateIconConfig}
-              ariaLabel="Select node state"
-            />
-            <AppNodeHeaderMenuAction
-              id={id}
-              type={"statusNode"}
-              data={data}
-              deletable={!data.isRootNode}
-            />
-          </NodeHeaderActions>
-        </NodeHeader>
+          <NodeHeader>
+            <NodeHeaderIcon>
+              <ChartLine size="16" />
+            </NodeHeaderIcon>
+            <NodeHeaderTitle>{data.title}</NodeHeaderTitle>
+            <NodeHeaderActions>
+              <IconSelect<StatusNodeState>
+                selectedIcon={data.state}
+                onSelectChange={(newState) => {
+                  updateNodeData(id, { state: newState });
+                }}
+                optionsAndIcons={statusNodeStateIconConfig}
+                ariaLabel="Select node state"
+              />
+              <AppNodeHeaderMenuAction
+                id={id}
+                type={"statusNode"}
+                data={data}
+                deletable={!data.isRootNode}
+              />
+            </NodeHeaderActions>
+          </NodeHeader>
+          <NodeSection children={data.description}></NodeSection>
+          <NodeSection
+            children={
+              data.git ? (
+                <GitRevision
+                  revision={data.git}
+                  onClickPinRevision={addGitRevision}
+                />
+              ) : null
+            }
+          />
+        </NodeContent>
         {!data.isRootNode && (
           <BaseHandle
             id="target-1"
@@ -158,22 +172,6 @@ export const StatusNode = memo(
             position={Position.Left}
             // isConnectable={false}
           />
-        )}
-        {data.description && <div className="py-2">{data.description}</div>}
-        {data.git && (
-          <NodeHeader
-            className={cn(
-              "-mx-2 px-2",
-              data.description
-                ? cn("border-t", statusNodeStateClasses[data.state].border)
-                : "",
-            )}
-          >
-            <GitRevision
-              revision={data.git}
-              onClickPinRevision={addGitRevision}
-            />
-          </NodeHeader>
         )}
         <BaseHandle id="source-1" type="source" position={Position.Right} />
       </BaseNode>

--- a/frontend/src/components/state-colors-icons.tsx
+++ b/frontend/src/components/state-colors-icons.tsx
@@ -53,22 +53,28 @@ export const statusNodeStateClasses: Record<
     bg: string;
     /** Border classes */
     border: string;
+    /** Divide classes */
+    divide: string;
   }
 > = {
   unknown: {
     bg: "bg-zinc-100 dark:bg-zinc-700",
     border: "border-zinc-300 dark:border-zinc-500",
+    divide: "divide-zinc-300 dark:divide-zinc-500",
   },
   progress: {
     bg: "bg-amber-100 dark:bg-amber-950",
     border: "border-amber-300 dark:border-amber-800",
+    divide: "divide-amber-300 dark:divide-amber-800",
   },
   fail: {
     bg: "bg-red-100 dark:bg-red-950",
     border: "border-red-300 dark:border-red-800",
+    divide: "divide-red-300 dark:divide-red-800",
   },
   success: {
     bg: "bg-emerald-100 dark:bg-emerald-950",
     border: "border-emerald-300 dark:border-emerald-800",
+    divide: "divide-emerald-300 dark:divide-emerald-800",
   },
 } as const;


### PR DESCRIPTION
* Fix node width for simpler layout to w-xs (320px)
* Define divide color classes for different status node states
* Use divide-y class for dividers between node sections
* Remove padding from BaseNode
* Remove complex padding and margin layout between base node, header and further content