### PR TITLE
Optional branch creation (1. iteration)

### DIFF
--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -1,6 +1,7 @@
 import log from "loglevel";
 import createClient, { type Middleware } from "openapi-fetch";
 import type { paths } from "./types/api";
+import type { GitMetadata } from "./types/nodes";
 
 const logger = log.getLogger("api-client");
 
@@ -36,3 +37,17 @@ const loggerMiddleware: Middleware = {
 
 export const client = createClient<paths>({ baseUrl: "/" });
 client.use(loggerMiddleware);
+
+export async function getCurrentHead(): Promise<GitMetadata> {
+  const rev = "HEAD";
+  const { data, error } = await client.GET("/api/v1/git/commit/{rev}", {
+    params: { path: { rev } },
+  });
+
+  if (error) {
+    const errorMessage = `Error getting current HEAD revision: ${error.message}`;
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+  return { rev: data.id, summary: data.summary, isTag: false };
+}

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -1,7 +1,6 @@
 import log from "loglevel";
 import createClient, { type Middleware } from "openapi-fetch";
 import type { paths } from "./types/api";
-import type { GitMetadata } from "./types/nodes";
 
 const logger = log.getLogger("api-client");
 
@@ -38,6 +37,14 @@ const loggerMiddleware: Middleware = {
 export const client = createClient<paths>({ baseUrl: "/" });
 client.use(loggerMiddleware);
 
+export interface GitMetadata {
+  /** Tag or commit ID */
+  rev: string;
+  /** Summary of the  */
+  summary: string;
+  /** Whether {@link rev} refers to a tag */
+  isTag: boolean;
+}
 export async function getCurrentHead(): Promise<GitMetadata> {
   const rev = "HEAD";
   const { data, error } = await client.GET("/api/v1/git/commit/{rev}", {

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -111,7 +111,7 @@ export async function fetchCommits(filter?: string): Promise<GitMetadata[]> {
 
 export async function fetchTags(filter?: string): Promise<GitMetadata[]> {
   const { data, error } = await client.GET("/api/v1/git/tags", {
-    params: { query: { prefix: filter } },
+    params: { query: { filter } },
   });
 
   if (error) {
@@ -129,7 +129,7 @@ export async function fetchTags(filter?: string): Promise<GitMetadata[]> {
 
 export async function fetchBranches(filter?: string): Promise<GitMetadata[]> {
   const { data, error } = await client.GET("/api/v1/git/branches", {
-    params: { query: { filter: filter } },
+    params: { query: { filter } },
   });
 
   if (error) {

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -69,7 +69,7 @@ export function isBranchMetadata(
   return metadata.type === "branch";
 }
 
-export function gitMetaDataSchema() {
+export function getGitMetaDataSchema() {
   return z.object({
     rev: z.string(),
     summary: z.string(),

--- a/frontend/src/components/async-combobox.tsx
+++ b/frontend/src/components/async-combobox.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/command";
 import { Command as CommandPrimitive } from "cmdk";
 import debounce from "lodash.debounce";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   Popover,
@@ -38,7 +38,7 @@ interface AsyncComboboxProps<ItemType> {
   /** Render function for dropdown items */
   renderDropdownItem: (item: ItemType) => React.ReactElement;
   /** Render the current value in the input button */
-  renderValue: (item: ItemType) => ReactNode;
+  renderValue: (item: ItemType) => string;
   /**
    * Get the value to use for a ItemType. This is used to check if a dropdown item is the current
    * value and as the key for dropdown elements
@@ -67,7 +67,7 @@ export const AsyncCombobox = <ItemType,>({
   commandProps = {},
 }: AsyncComboboxProps<ItemType>) => {
   const [open, setOpen] = useState(false);
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState(value ? renderValue(value) : "");
   const [items, setItems] = useState<ItemType[]>([]);
   const [loading, setLoading] = useState(false);
 

--- a/frontend/src/components/create-node-dialog.tsx
+++ b/frontend/src/components/create-node-dialog.tsx
@@ -36,7 +36,12 @@ export const CreateNodeDialog = () => {
     if (pendingNode) {
       if (pendingNode.type === "statusNode") {
         form.reset({
-          data: { title: "", description: "", state: "unknown", git: null },
+          data: {
+            title: "",
+            description: "",
+            state: "unknown",
+            git: pendingNode.defaultRev,
+          },
           type: pendingNode.type,
         });
       } else {

--- a/frontend/src/components/flows-dialog.tsx
+++ b/frontend/src/components/flows-dialog.tsx
@@ -1,4 +1,4 @@
-import { getCurrentHead } from "@/client";
+import { fetchCurrentHeadCommit } from "@/client";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -158,7 +158,7 @@ export const FlowsDialog: React.FC<FlowsDialogProps> = ({
     }
     if (await createFlow(values.flowName)) {
       const bounds = reactflowRef.current.getBoundingClientRect();
-      const currentHead = await getCurrentHead();
+      const currentHead = await fetchCurrentHeadCommit();
 
       setPendingNode({
         type: "statusNode",

--- a/frontend/src/components/flows-dialog.tsx
+++ b/frontend/src/components/flows-dialog.tsx
@@ -1,3 +1,4 @@
+import { getCurrentHead } from "@/client";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -157,6 +158,7 @@ export const FlowsDialog: React.FC<FlowsDialogProps> = ({
     }
     if (await createFlow(values.flowName)) {
       const bounds = reactflowRef.current.getBoundingClientRect();
+      const currentHead = await getCurrentHead();
 
       setPendingNode({
         type: "statusNode",
@@ -164,6 +166,7 @@ export const FlowsDialog: React.FC<FlowsDialogProps> = ({
           x: bounds.x + bounds.width / 2,
           y: bounds.y + bounds.height / 2,
         }),
+        defaultRev: currentHead,
       });
       form.reset();
     }

--- a/frontend/src/components/git-revision.tsx
+++ b/frontend/src/components/git-revision.tsx
@@ -1,4 +1,4 @@
-import type { GitMetadata } from "@/client";
+import { isTagMetadata, type GitMetadata } from "@/client";
 import { cn } from "@/lib/utils";
 import { formatGitRevision } from "@/types/nodes";
 import { GitBranch, Pin, Tag } from "lucide-react";
@@ -45,7 +45,7 @@ export const GitRevision = ({
 
   return (
     <div className={cn("flex flex-1 items-center text-muted-foreground")}>
-      {revision.isTag ? <Tag size={16} /> : <GitBranch size={16} />}
+      {isTagMetadata(revision) ? <Tag size={16} /> : <GitBranch size={16} />}
 
       <span className="flex-1 font-mono px-3  truncate align-middle">
         {formattedRev}

--- a/frontend/src/components/git-revision.tsx
+++ b/frontend/src/components/git-revision.tsx
@@ -1,5 +1,6 @@
+import type { GitMetadata } from "@/client";
 import { cn } from "@/lib/utils";
-import { formatGitRevision, type GitMetadata } from "@/types/nodes";
+import { formatGitRevision } from "@/types/nodes";
 import { GitBranch, Pin, Tag } from "lucide-react";
 import {
   useCallback,

--- a/frontend/src/components/node-form.tsx
+++ b/frontend/src/components/node-form.tsx
@@ -1,4 +1,4 @@
-import { client, type GitMetadata } from "@/client";
+import { fetchCommits, fetchTags, type GitMetadata } from "@/client";
 import type { AppNodeType } from "@/types/nodes";
 import { AppNodeSchema, formatGitRevision } from "@/types/nodes";
 import log from "loglevel";
@@ -51,49 +51,12 @@ export const NodeForm = ({
   submitButtonText,
   cancelComponent,
 }: NodeFormProps) => {
-  const fetchGitRevisions = async (value: string): Promise<GitMetadata[]> => {
-    const { data, error } = await client.GET("/api/v1/git/commits", {
-      params: { query: { filter: value } },
-    });
-    if (data) {
-      return [
-        ...data.commits.map((commit) => {
-          return {
-            rev: commit.id,
-            summary: commit.summary,
-            isTag: false,
-          };
-        }),
-      ];
-    }
-    throw new Error(`Failed to fetch Git revisions: ${error.message}`);
-  };
-
-  const fetchGitTags = async (value: string): Promise<GitMetadata[]> => {
-    const { data, error } = await client.GET("/api/v1/git/tags", {
-      params: { query: { prefix: value } },
-    });
-
-    if (data) {
-      return [
-        ...data.tags.map((data) => {
-          return {
-            rev: data.tag,
-            summary: data.commit.summary,
-            isTag: true,
-          };
-        }),
-      ];
-    }
-    throw new Error(`Failed to fetch Git tags: ${error.message}`);
-  };
-
   const fetchGitTagsAndRevisions = async (
     value: string,
   ): Promise<GitMetadata[]> => {
     const [revisions, tags] = await Promise.all([
-      fetchGitRevisions(value),
-      fetchGitTags(value),
+      fetchCommits(value),
+      fetchTags(value),
     ]);
     return [...revisions, ...tags];
   };

--- a/frontend/src/components/node-form.tsx
+++ b/frontend/src/components/node-form.tsx
@@ -5,6 +5,7 @@ import {
   formatGitRevision,
   type GitMetadata,
 } from "@/types/nodes";
+import log from "loglevel";
 import { useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { z } from "zod";
@@ -31,6 +32,8 @@ const GitRevCommandItem = (m: GitMetadata) => {
     </div>
   );
 };
+
+const logger = log.getLogger("node-form");
 
 interface NodeFormProps {
   /** Node type  */
@@ -105,7 +108,7 @@ export const NodeForm = ({
       <form
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onSubmit={form.handleSubmit(submitForm, (errors) => {
-          console.log(errors);
+          logger.info("Form submission error", errors);
         })}
         className="space-y-8"
       >
@@ -193,11 +196,7 @@ export const NodeForm = ({
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           {cancelComponent}
           <Button
-            disabled={
-              !form.formState.isValid ||
-              form.formState.isSubmitting ||
-              gitRevSuggestionsIsOpen
-            }
+            disabled={form.formState.isSubmitting || gitRevSuggestionsIsOpen}
             type="submit"
           >
             {submitButtonText}

--- a/frontend/src/components/node-form.tsx
+++ b/frontend/src/components/node-form.tsx
@@ -1,10 +1,6 @@
-import { client } from "@/client";
+import { client, type GitMetadata } from "@/client";
 import type { AppNodeType } from "@/types/nodes";
-import {
-  AppNodeSchema,
-  formatGitRevision,
-  type GitMetadata,
-} from "@/types/nodes";
+import { AppNodeSchema, formatGitRevision } from "@/types/nodes";
 import log from "loglevel";
 import { useState } from "react";
 import type { UseFormReturn } from "react-hook-form";

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -302,6 +302,7 @@ export const useStore = create<AppState>()(
           eventScreenPosition: { x: clientX, y: clientY },
           type: nodeType,
           fromNodeId: fromNode.id,
+          defaultRev: undefined,
         });
       },
       setEdgeType: (newType) => {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -429,7 +429,7 @@ export interface operations {
     list_branches: {
         parameters: {
             query?: {
-                /** @description Glob filter for */
+                /** @description string filter against with the branch name is matched */
                 filter?: string | null;
             };
             header?: never;
@@ -545,8 +545,8 @@ export interface operations {
     list_tags: {
         parameters: {
             query?: {
-                /** @description Prefix of the tag names to list */
-                prefix?: string | null;
+                /** @description String filter against which the tag name is matched. */
+                filter?: string | null;
             };
             header?: never;
             path?: never;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -41,6 +41,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/git/branches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List branches
+         * @description List all local branches in the repository, optionally filtered by a glob pattern.
+         */
+        get: operations["list_branches"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/git/commit/{rev}": {
         parameters: {
             query?: never;
@@ -129,6 +149,12 @@ export interface components {
              * @description HTTP status code
              */
             status: number;
+        };
+        Branch: {
+            /** @description Commit ID of the branch head */
+            head: components["schemas"]["Commit"];
+            /** @description Name of the branch */
+            name: string;
         };
         Commit: {
             author: components["schemas"]["Signature"];
@@ -387,6 +413,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiStatusDetailResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiStatusDetailResponse"];
+                };
+            };
+        };
+    };
+    list_branches: {
+        parameters: {
+            query?: {
+                /** @description Glob filter for */
+                filter?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of branches */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Branch"][];
                 };
             };
             /** @description Internal server error */

--- a/frontend/src/types/nodes.ts
+++ b/frontend/src/types/nodes.ts
@@ -52,6 +52,8 @@ interface PendingNodeData<NodeType extends string> {
   type: NodeType;
   // Node the dropped edge is connected to
   fromNodeId?: string;
+  // default revision to display during creation
+  defaultRev?: GitMetadata;
 }
 
 export type PendingAppNodeData =

--- a/frontend/src/types/nodes.ts
+++ b/frontend/src/types/nodes.ts
@@ -1,14 +1,6 @@
+import type { GitMetadata } from "@/client";
 import type { Node } from "@xyflow/react";
 import { z } from "zod";
-
-export interface GitMetadata {
-  /** Tag or commit ID */
-  rev: string;
-  /** Summary of the  */
-  summary: string;
-  /** Whether {@link rev} refers to a tag */
-  isTag: boolean;
-}
 
 /**
  * Format the revision of a {@link GitMetadata} object. If it is a tag, the {@link GitMetadata.rev}

--- a/frontend/src/types/nodes.ts
+++ b/frontend/src/types/nodes.ts
@@ -1,4 +1,8 @@
-import type { GitMetadata } from "@/client";
+import {
+  gitMetaDataSchema,
+  isCommitMetadata,
+  type GitMetadata,
+} from "@/client";
 import type { Node } from "@xyflow/react";
 import { z } from "zod";
 
@@ -9,7 +13,10 @@ import { z } from "zod";
  * @returns Git revision
  */
 export const formatGitRevision = (git: GitMetadata) => {
-  return git.isTag ? git.rev : git.rev.slice(0, 7);
+  if (isCommitMetadata(git)) {
+    return git.rev.slice(0, 7);
+  }
+  return git.rev;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -77,13 +84,7 @@ export const AppNodeSchema = z.discriminatedUnion("type", [
     data: z.object({
       ...commonNodeDataFields,
       state: z.enum(["unknown", "progress", "fail", "success"]),
-      git: z
-        .object({
-          rev: z.string(),
-          isTag: z.boolean(),
-          summary: z.string(),
-        })
-        .nullable(),
+      git: gitMetaDataSchema().nullable(),
     }),
   }),
 ]);

--- a/frontend/src/types/nodes.ts
+++ b/frontend/src/types/nodes.ts
@@ -1,5 +1,5 @@
 import {
-  gitMetaDataSchema,
+  getGitMetaDataSchema,
   isCommitMetadata,
   type GitMetadata,
 } from "@/client";
@@ -84,7 +84,7 @@ export const AppNodeSchema = z.discriminatedUnion("type", [
     data: z.object({
       ...commonNodeDataFields,
       state: z.enum(["unknown", "progress", "fail", "success"]),
-      git: gitMetaDataSchema().nullable(),
+      git: getGitMetaDataSchema().nullable(),
     }),
   }),
 ]);

--- a/src/web/api/v1/git.rs
+++ b/src/web/api/v1/git.rs
@@ -1,4 +1,5 @@
 use crate::{web, web::api};
+
 use axum::extract::{Path, Query, State};
 use axum::{Json, routing};
 use serde::{Deserialize, Serialize};
@@ -9,6 +10,7 @@ pub fn router() -> routing::Router<web::AppState> {
         .route("/commits", routing::get(list_commits))
         .route("/commit/{commit_id}", routing::get(get_commit))
         .route("/tags", routing::get(list_tags))
+        .route("/branches", routing::get(list_branches))
 }
 
 #[derive(Serialize, ToSchema)]
@@ -68,7 +70,7 @@ impl<'repo> From<git2::Commit<'repo>> for Commit {
 }
 
 #[derive(utoipa::OpenApi)]
-#[openapi(paths(get_commit, list_commits,  list_tags), tags((name = "Git Repository", description="Git Repository related endpoints")) )]
+#[openapi(paths(get_commit, list_commits,  list_tags, list_branches), tags((name = "Git Repository", description="Git Repository related endpoints")) )]
 pub(super) struct ApiDoc;
 
 #[utoipa::path(
@@ -431,6 +433,68 @@ async fn list_tags(
     Ok(Json(ListTagsResponse::try_from_tagged_commits(
         tagged_commits,
     )?))
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct Branch {
+    /// Name of the branch
+    name: String,
+    /// Commit ID of the branch head
+    head: Commit,
+}
+
+#[derive(ToSchema, Serialize, Deserialize, IntoParams)]
+#[serde(rename_all = "camelCase")]
+struct ListBranchesQuery {
+    /// Glob filter for
+    filter: Option<String>,
+}
+
+/// List branches in the repository
+#[utoipa::path(
+    get,
+    path = "/branches",
+    summary = "List branches",
+    description = "List all local branches in the repository, optionally filtered by a glob pattern.",
+    params(ListBranchesQuery),
+    responses(
+        (status = http::StatusCode::OK, description = "List of branches", body = Vec<Branch>),
+        (status = http::StatusCode::INTERNAL_SERVER_ERROR, description = "Internal server error", body = api::ApiStatusDetailResponse),
+    )
+)]
+async fn list_branches(
+    State(state): State<web::AppState>,
+    Query(query): Query<ListBranchesQuery>,
+) -> Result<Json<Vec<Branch>>, api::AppError> {
+    let guard = state.repo().lock().await;
+    let repo = guard
+        .as_ref()
+        .ok_or_else(|| api::AppError::InternalServerError("Repository not found".to_string()))?;
+
+    let filter = &query.filter.unwrap_or("".to_string());
+    let local_branches = repo
+        .branches(Some(git2::BranchType::Local))
+        .map_err(|e| api::AppError::InternalServerError(format!("Failed to list branches: {e}")))?;
+    let branches = local_branches
+        .filter_map(Result::ok)
+        .filter_map(|(b, _)| {
+            let name = b.name().ok()??;
+            if !name.contains(filter) {
+                return None; // Skip branches that do not match the filter
+            }
+
+            let rev = b.get();
+            let commit = rev.peel_to_commit().ok()?;
+            let branch = Branch {
+                name: name.to_string(),
+                head: Commit::from(commit),
+            };
+            Some(branch)
+        })
+        .collect();
+
+    Ok(Json(branches))
 }
 
 fn get_commit_for_revision<'repo>(

--- a/src/web/api/v1/git.rs
+++ b/src/web/api/v1/git.rs
@@ -360,8 +360,8 @@ async fn list_commits(
 #[derive(ToSchema, Serialize, Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
 struct ListTagsQuery {
-    /// Prefix of the tag names to list
-    prefix: Option<String>,
+    /// String filter against which the tag name is matched.
+    filter: Option<String>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -423,7 +423,7 @@ async fn list_tags(
         .ok_or_else(|| api::AppError::InternalServerError("Repository not found".to_string()))?;
 
     let tag_names = repo
-        .tag_names(query.prefix.as_deref().map(to_safe_glob).as_deref())
+        .tag_names(query.filter.as_deref().map(to_safe_glob).as_deref())
         .map_err(|e| api::AppError::InternalServerError(format!("Could not get tags: {e}")))?;
 
     let tagged_commits = tag_names
@@ -447,7 +447,7 @@ struct Branch {
 #[derive(ToSchema, Serialize, Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
 struct ListBranchesQuery {
-    /// Glob filter for
+    /// string filter against with the branch name is matched
     filter: Option<String>,
 }
 
@@ -562,5 +562,5 @@ fn to_safe_glob(prefix: &str) -> String {
         .replace('*', "\\*")
         .replace('[', "\\[")
         .replace('?', "\\?");
-    format!("{escaped}*")
+    format!("*{escaped}*")
 }


### PR DESCRIPTION
- add a backend API to list branches
- add a default revision for the initial root status node
- move client functionality to a single place 
Refs: #31 