### PR TITLE
fix(AppNodeSchema): Fix type of Git metadata

### DIFF
--- a/frontend/src/components/nodes.tsx
+++ b/frontend/src/components/nodes.tsx
@@ -14,12 +14,13 @@ import {
 } from "@/components/node-header";
 import { cn } from "@/lib/utils";
 import { useStore } from "@/store";
-import {
-  type ActionNode as ActionNodeType,
-  type StatusNodeState,
-  type StatusNode as StatusNodeType,
+import type {
+  ActionNode as ActionNodeType,
+  EditAppNodeData,
+  StatusNodeState,
+  StatusNode as StatusNodeType,
 } from "@/types/nodes";
-import type { AppState, EditAppNodeData } from "@/types/state";
+import type { AppState } from "@/types/state";
 import { Position, useReactFlow, type NodeProps } from "@xyflow/react";
 import {
   ChartLine,

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -302,7 +302,7 @@ export const useStore = create<AppState>()(
           eventScreenPosition: { x: clientX, y: clientY },
           type: nodeType,
           fromNodeId: fromNode.id,
-          defaultRev: undefined,
+          defaultRev: null,
         });
       },
       setEdgeType: (newType) => {

--- a/frontend/src/types/nodes.ts
+++ b/frontend/src/types/nodes.ts
@@ -51,13 +51,26 @@ interface PendingNodeData<NodeType extends string> {
   type: NodeType;
   // Node the dropped edge is connected to
   fromNodeId?: string;
-  // default revision to display during creation
-  defaultRev?: GitMetadata;
+  // Default revision to display during creation
+  defaultRev: GitMetadata | null;
 }
 
 export type PendingAppNodeData =
   | PendingNodeData<"actionNode">
   | PendingNodeData<"statusNode">;
+
+interface EditNodeData<
+  NodeType extends string,
+  NodeDataType extends Record<string, unknown>,
+> {
+  id: string;
+  type: NodeType;
+  data: NodeDataType;
+}
+
+export type EditAppNodeData =
+  | EditNodeData<"actionNode", ActionNodeData>
+  | EditNodeData<"statusNode", StatusNodeData>;
 
 export function isStatusNode(node: Node): node is StatusNode {
   return node.type == "statusNode";

--- a/frontend/src/types/state.ts
+++ b/frontend/src/types/state.ts
@@ -7,35 +7,17 @@ import {
 } from "@xyflow/react";
 import { type FlowMetadata } from "./api-types";
 import type { EdgeType } from "./edge";
-import type {
-  ActionNodeData,
-  AppNode,
-  PendingAppNodeData,
-  StatusNodeData,
-} from "./nodes";
+import type { AppNode, EditAppNodeData, PendingAppNodeData } from "./nodes";
 
 export interface FlowIdAndName {
   id: string;
   name: string;
 }
 
-interface EditNodeData<
-  NodeType extends string,
-  NodeDataType extends Record<string, unknown>,
-> {
-  id: string;
-  type: NodeType;
-  data: NodeDataType;
-}
-
 interface NodesAndEdges {
   nodes: AppNode[];
   edges: Edge[];
 }
-
-export type EditAppNodeData =
-  | EditNodeData<"actionNode", ActionNodeData>
-  | EditNodeData<"statusNode", StatusNodeData>;
 
 export interface AppState {
   /** Nodes of the currently opened flow */


### PR DESCRIPTION
`PendingNodeData::defaultRev` is defined as `GitMetadata | undefined` while the `AppNodeSchema` defined it as `nullable`. When creating a node without setting a Git revision this leads to a form validation error. This change aligns the `AppNodeSchema.git` type as `optional`.

Closes #55 