### PR TITLE
fix(frontend): Fix prod build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,40 +10,8 @@ export default defineConfig({
   root: "./frontend",
   plugins: [react(), tailwindcss()],
   build: {
+    chunkSizeWarningLimit: 1024,
     rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            if (
-              id.includes("radix-ui") ||
-              id.includes("ui") ||
-              id.includes("lucide") ||
-              id.includes("sonner") ||
-              id.includes("zod") ||
-              id.includes("react-diff-viewer") ||
-              id.includes("emotion") ||
-              id.includes("react-remove--scroll") ||
-              id.includes("react-hook-form")
-            ) {
-              return "ui";
-            }
-            if (
-              id.includes("d3") ||
-              id.includes("xyflow") ||
-              id.includes("zustand")
-            ) {
-              return "reactflow";
-            }
-
-            if (id.includes("react")) {
-              return "react";
-            }
-            return "modules";
-          }
-
-          return null;
-        },
-      },
       plugins: shouldAnalyze
         ? [
             visualizer({


### PR DESCRIPTION
The manual chunking broke the production build because of unloaded dependencies.

```
Uncaught TypeError: can't access property "useLayoutEffect" of undefined
```

As we are anyways serving our own frontend, increase the warning limit.