### PR TITLE
Feat: Allow checking out git revision

### DIFF
--- a/backend/git2-ox/src/repository.rs
+++ b/backend/git2-ox/src/repository.rs
@@ -29,9 +29,14 @@ impl Repository {
         &self.repo
     }
 
-    /// Get the name of the current branch
+    /// Get the name of the current branch, None in case of a detached HEAD
     pub fn current_branch_name(&self) -> Option<String> {
-        self.repo().head().ok()?.shorthand().map(|s| s.to_string())
+        let head = self.repo().head().ok()?;
+        if head.is_branch() {
+            head.shorthand().map(|s| s.to_string())
+        } else {
+            None
+        }
     }
 
     /// Returns an iterator over Commits in the repository from `head_rev` to `base_rev`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -242,7 +242,13 @@ export const App = () => {
           }}
         />
       </ReactFlow>
-      <Toaster position="bottom-right" richColors />
+      <Toaster
+        position="bottom-left"
+        toastOptions={{
+          className: "max-w-xs text-sm", // global default for all toasts
+        }}
+        richColors
+      />
     </div>
   );
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -243,9 +243,10 @@ export const App = () => {
         />
       </ReactFlow>
       <Toaster
-        position="bottom-left"
+        position="bottom-right"
         toastOptions={{
-          className: "max-w-xs text-sm", // global default for all toasts
+          className: "max-w-xs text-sm",
+          duration: 1500,
         }}
         richColors
       />

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -104,6 +104,17 @@ export const fetchCommitForRevision = async (
   return { rev: data.id, summary: data.summary, type: "commit" };
 };
 
+export async function checkoutRevision(revision: string): Promise<void> {
+  const { error } = await client.POST("/api/v1/git/commit/{revision}", {
+    params: { path: { revision } },
+  });
+  if (error) {
+    throw new Error(
+      `Error checking out revision ${revision}: ${error.message}`,
+    );
+  }
+}
+
 export async function fetchCommits(filter?: string): Promise<GitMetadata[]> {
   const { data, error } = await client.GET("/api/v1/git/commits", {
     params: { query: { filter } },

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -216,3 +216,33 @@ export async function createTag(
     type: "tag",
   };
 }
+
+export interface GitStatus {
+  /** current checked out branch/ commit (detached HEAD) */
+  revision: BranchMetadata | CommitMetadata;
+}
+export async function fetchStatus(): Promise<GitStatus> {
+  const { data, error } = await client.GET("/api/v1/git/repository/status", {});
+  if (error) {
+    throw new Error(`Error fetching Git status: ${error.message}`);
+  }
+
+  let revision;
+  if (data.currentBranch) {
+    revision = {
+      rev: data.currentBranch,
+      summary: data.head.summary,
+      type: "branch",
+    } as BranchMetadata;
+  } else {
+    revision = {
+      rev: data.head.id,
+      summary: data.head.summary,
+      type: "commit",
+    } as CommitMetadata;
+  }
+
+  return {
+    revision,
+  };
+}

--- a/frontend/src/components/git-graph-sliding-panel.tsx
+++ b/frontend/src/components/git-graph-sliding-panel.tsx
@@ -34,10 +34,12 @@ export const GitGraphSlidingPanel: React.FC<GitGraphSlidingPanelProps> = ({
 
   const [data, setData] = React.useState<GitGraphData>();
   const [loading, setLoading] = React.useState(false);
+  const [openIndex, setOpenIndex] = React.useState<null | number>(null);
+  const [gitDiffIsVisible, setGitDiffIsVisible] = React.useState(false);
 
   React.useEffect(() => {
-    // This effect can be used to perform any side effects when the panel opens or closes
     if (isOpen && gitRevisions.length >= 1) {
+      setLoading(true);
       client
         .GET("/api/v1/git/commits", {
           params: {
@@ -55,6 +57,7 @@ export const GitGraphSlidingPanel: React.FC<GitGraphSlidingPanelProps> = ({
           setLoading(false);
         })
         .catch((error: unknown) => {
+          setLoading(false);
           let message = "";
           if (
             typeof error === "object" &&
@@ -70,13 +73,10 @@ export const GitGraphSlidingPanel: React.FC<GitGraphSlidingPanelProps> = ({
     }
   }, [isOpen, gitRevisions]);
 
-  const [openIndex, setOpenIndex] = React.useState<null | number>(null);
-
   const toggle = (index: number) => {
     setOpenIndex(openIndex === index ? null : index);
   };
 
-  const [gitDiffIsVisible, setGitDiffIsVisible] = React.useState(false);
   return (
     <SlidingPanel isOpen={isOpen} onClose={onClose}>
       <div>
@@ -87,15 +87,8 @@ export const GitGraphSlidingPanel: React.FC<GitGraphSlidingPanelProps> = ({
           </div>
         ) : (
           <div className="flex">
-            <GitDiffView
-              isVisible={gitDiffIsVisible}
-              baseRev={gitRevisions[0]}
-              headRev={gitRevisions[1] ?? ""}
-              diffs={data?.diffs ?? []}
-              className="h-screen flex-col flex mr-4"
-            />
-            {/* sliding panel right column */}
-            <div className="flex-none h-screen space-y-4">
+            {/* Left side: Commit Tree */}
+            <div className="flex-none h-screen space-y-4 mr-4">
               <h2 className="text-lg font-semibold">Git Tree</h2>
               <Button
                 className="cursor-pointer"
@@ -107,64 +100,68 @@ export const GitGraphSlidingPanel: React.FC<GitGraphSlidingPanelProps> = ({
                 {gitDiffIsVisible ? "Hide Diff" : "Show Diff"}
               </Button>
               <div className="h-screen overflow-y-auto font-mono w-full">
-                {data?.commits.length == 0
+                {data?.commits.length === 0
                   ? `No commits available for range ${gitRevisions[0]}..${gitRevisions[1]}`
-                  : data?.commits.map((commit, index) => {
-                      return (
-                        <div key={index} className="border-b">
-                          <button
-                            onClick={() => {
-                              toggle(index);
-                            }}
-                            className="text-left w-full px-2 py-4 hover:bg-secondary/80 cursor-pointer"
-                          >
-                            <div className="flex flex-col gap-1 w-full">
-                              <div className="flex gap-2 items-center w-full overflow-hidden">
-                                <span className="font-bold shrink-0">
-                                  {commit.id.slice(0, 7)}
-                                </span>
-                                <div className="truncate w-full">
-                                  {commit.summary}
-                                </div>
-                              </div>
-                              <div className="text-sm text-muted-foreground">
-                                {commit.author.name} •{" "}
-                                {formatDistanceToNow(commit.time, {
-                                  addSuffix: true,
-                                })}
+                  : data?.commits.map((commit, index) => (
+                      <div key={index} className="border-b">
+                        <button
+                          onClick={() => {
+                            toggle(index);
+                          }}
+                          className="text-left w-full px-2 py-4 hover:bg-secondary/80 cursor-pointer"
+                        >
+                          <div className="flex flex-col gap-1 w-full">
+                            <div className="flex gap-2 items-center w-full overflow-hidden">
+                              <span className="font-bold shrink-0">
+                                {commit.id.slice(0, 7)}
+                              </span>
+                              <div className="truncate w-full">
+                                {commit.summary}
                               </div>
                             </div>
-                          </button>
-                          {openIndex === index && (
-                            <div
-                              key="content"
-                              className="overflow-hidden p-4 text-sm text-muted-foreground"
-                            >
-                              {commit.body !== "" && <p>{commit.body}</p>}
-                              <p>
-                                <strong>Date:</strong>{" "}
-                                {new Date(commit.time).toLocaleString()}
-                              </p>
-                              <p>
-                                <strong>Author:</strong> {commit.author.name}{" "}
-                                {commit.author.email && (
-                                  <span> {commit.author.email}</span>
-                                )}
-                              </p>
-                              <p>
-                                <strong>Committer:</strong>{" "}
-                                {commit.committer.name}{" "}
-                                {commit.author.email && (
-                                  <span> {commit.committer.email}</span>
-                                )}
-                              </p>
+                            <div className="text-sm text-muted-foreground">
+                              {commit.author.name} •{" "}
+                              {formatDistanceToNow(commit.time, {
+                                addSuffix: true,
+                              })}
                             </div>
-                          )}
-                        </div>
-                      );
-                    })}
+                          </div>
+                        </button>
+                        {openIndex === index && (
+                          <div className="overflow-hidden p-4 text-sm text-muted-foreground">
+                            {commit.body !== "" && <p>{commit.body}</p>}
+                            <p>
+                              <strong>Date:</strong>{" "}
+                              {new Date(commit.time).toLocaleString()}
+                            </p>
+                            <p>
+                              <strong>Author:</strong> {commit.author.name}{" "}
+                              {commit.author.email && (
+                                <span> {commit.author.email}</span>
+                              )}
+                            </p>
+                            <p>
+                              <strong>Committer:</strong>{" "}
+                              {commit.committer.name}{" "}
+                              {commit.committer.email && (
+                                <span> {commit.committer.email}</span>
+                              )}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    ))}
               </div>
             </div>
+
+            {/* Right side: Git Diff View */}
+            <GitDiffView
+              isVisible={gitDiffIsVisible}
+              baseRev={gitRevisions[0]}
+              headRev={gitRevisions[1] ?? ""}
+              diffs={data?.diffs ?? []}
+              className="h-screen flex-col flex"
+            />
           </div>
         )}
       </div>

--- a/frontend/src/components/git-revision.tsx
+++ b/frontend/src/components/git-revision.tsx
@@ -3,13 +3,14 @@ import { cn } from "@/lib/utils";
 import { useStore } from "@/store";
 import { formatGitRevision } from "@/types/nodes";
 import type { AppState } from "@/types/state";
-import { GitBranch, Pin, Tag } from "lucide-react";
+import { ArrowDownToLine, GitBranch, Pin, Tag } from "lucide-react";
 import React from "react";
 import { useShallow } from "zustand/react/shallow";
 import { ActionButton, CopyButton } from "./action-button";
 
 const selector = (s: AppState) => ({
   addGitRevision: s.addGitRevision,
+  checkoutGitRevision: s.checkoutGitRevision,
 });
 
 interface GitRevisionIconProps {
@@ -35,7 +36,9 @@ interface GitRevisionProps {
   revision: GitMetadata;
 }
 export const GitRevision = ({ revision }: GitRevisionProps) => {
-  const { addGitRevision } = useStore(useShallow(selector));
+  const { addGitRevision, checkoutGitRevision } = useStore(
+    useShallow(selector),
+  );
 
   const formattedRev = React.useMemo(() => {
     return formatGitRevision(revision);
@@ -57,6 +60,14 @@ export const GitRevision = ({ revision }: GitRevisionProps) => {
         className="size-6"
       />
       <CopyButton value={formattedRev} />
+      <ActionButton
+        tooltipContent="Checkout revision"
+        icon={<ArrowDownToLine />}
+        onClick={async () => {
+          await checkoutGitRevision(formattedRev);
+        }}
+        className="size-6"
+      />
     </div>
   );
 };

--- a/frontend/src/components/git-revisions-panel.tsx
+++ b/frontend/src/components/git-revisions-panel.tsx
@@ -26,6 +26,8 @@ const selector = (state: AppState) => ({
   gitStatus: state.gitStatus,
   prevGitStatus: state.prevGitStatus,
   restoreGitStatus: state.restoreGitStatus,
+  hasRevisions: state.gitRevisions.length > 0,
+  displayPanel: state.gitRevisions.length > 0 || state.gitStatus != null,
 });
 
 interface GitRevisionsPanelProps {
@@ -39,11 +41,10 @@ export const GitRevisionsPanel = ({ openGitGraph }: GitRevisionsPanelProps) => {
     gitStatus,
     prevGitStatus,
     restoreGitStatus,
+    hasRevisions,
+    displayPanel,
   } = useStore(useShallow(selector));
 
-  const hasRevisions = gitRevisions.length > 0;
-  const hasStatus = gitStatus != null;
-  const displayPanel = hasRevisions || hasStatus;
   const prevRevison = prevGitStatus
     ? formatGitRevision(prevGitStatus.revision)
     : "previous status";
@@ -52,7 +53,7 @@ export const GitRevisionsPanel = ({ openGitGraph }: GitRevisionsPanelProps) => {
     displayPanel && (
       <TooltipProvider>
         <Panel position="bottom-right">
-          {hasStatus && (
+          {gitStatus && (
             <GitStatusCard
               status={gitStatus}
               footer={() => (

--- a/frontend/src/components/git-revisions-panel.tsx
+++ b/frontend/src/components/git-revisions-panel.tsx
@@ -52,7 +52,7 @@ export const GitRevisionsPanel = ({ openGitGraph }: GitRevisionsPanelProps) => {
   return (
     displayPanel && (
       <TooltipProvider>
-        <Panel position="bottom-right">
+        <Panel position="bottom-left">
           {gitStatus && (
             <GitStatusCard
               status={gitStatus}

--- a/frontend/src/components/git-revisions-panel.tsx
+++ b/frontend/src/components/git-revisions-panel.tsx
@@ -6,15 +6,26 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useStore } from "@/store";
+import { formatGitRevision } from "@/types/nodes";
 import type { AppState } from "@/types/state";
 import { Panel } from "@xyflow/react";
 import { GitGraph, X } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
+import { GitStatusCard } from "./git-status-card";
 
 const selector = (state: AppState) => ({
   gitRevisions: state.gitRevisions,
   clearGitRevisions: state.clearGitRevisions,
+  gitStatus: state.gitStatus,
+  prevGitStatus: state.prevGitStatus,
+  restoreGitStatus: state.restoreGitStatus,
 });
 
 interface GitRevisionsPanelProps {
@@ -22,40 +33,78 @@ interface GitRevisionsPanelProps {
 }
 
 export const GitRevisionsPanel = ({ openGitGraph }: GitRevisionsPanelProps) => {
-  const { gitRevisions, clearGitRevisions } = useStore(useShallow(selector));
+  const {
+    gitRevisions,
+    clearGitRevisions,
+    gitStatus,
+    prevGitStatus,
+    restoreGitStatus,
+  } = useStore(useShallow(selector));
+
+  const hasRevisions = gitRevisions.length > 0;
+  const hasStatus = gitStatus != null;
+  const displayPanel = hasRevisions || hasStatus;
+  const prevRevison = prevGitStatus
+    ? formatGitRevision(prevGitStatus.revision)
+    : "previous status";
 
   return (
-    gitRevisions.length > 0 && (
-      <Panel position="bottom-right">
-        <Card className="w-80">
-          <CardHeader>
-            <CardTitle>Git Revisions</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {gitRevisions.map((rev, index) => (
-              <div key={index} className="p-2 border-b">
-                <span className="font-mono">{rev}</span>
-              </div>
-            ))}
-          </CardContent>
-          <CardFooter className="flex gap-2">
-            <Button
-              onClick={() => {
-                clearGitRevisions();
-              }}
-              variant="destructive"
-            >
-              <X /> Clear
-            </Button>
-            {gitRevisions.length === 2 && (
-              <Button onClick={openGitGraph} variant="outline">
-                <GitGraph />
-                Show Graph
-              </Button>
-            )}
-          </CardFooter>
-        </Card>
-      </Panel>
+    displayPanel && (
+      <TooltipProvider>
+        <Panel position="bottom-right">
+          {hasStatus && (
+            <GitStatusCard
+              status={gitStatus}
+              footer={() => (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={restoreGitStatus}
+                      variant="destructive"
+                      className="max-w-[150px] truncate"
+                    >
+                      Restore
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Checkout revision {prevRevison}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            />
+          )}
+          {hasRevisions && (
+            <Card className="w-80">
+              <CardHeader>
+                <CardTitle>Git Revisions</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {gitRevisions.map((rev, index) => (
+                  <div key={index} className="p-2 border-b">
+                    <span className="font-mono">{rev}</span>
+                  </div>
+                ))}
+              </CardContent>
+              <CardFooter className="flex gap-2">
+                <Button
+                  onClick={() => {
+                    clearGitRevisions();
+                  }}
+                  variant="destructive"
+                >
+                  <X /> Clear
+                </Button>
+                {gitRevisions.length === 2 && (
+                  <Button onClick={openGitGraph} variant="outline">
+                    <GitGraph />
+                    Show Graph
+                  </Button>
+                )}
+              </CardFooter>
+            </Card>
+          )}
+        </Panel>
+      </TooltipProvider>
     )
   );
 };

--- a/frontend/src/components/git-revisions-panel.tsx
+++ b/frontend/src/components/git-revisions-panel.tsx
@@ -59,7 +59,13 @@ export const GitRevisionsPanel = ({ openGitGraph }: GitRevisionsPanelProps) => {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      onClick={restoreGitStatus}
+                      onClick={() => {
+                        restoreGitStatus()
+                          .then()
+                          .catch((e: unknown) => {
+                            console.warn("Failed to restore git status:", e);
+                          });
+                      }}
                       variant="destructive"
                       className="max-w-[150px] truncate"
                     >

--- a/frontend/src/components/git-status-card.tsx
+++ b/frontend/src/components/git-status-card.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { formatGitRevision } from "@/types/nodes";
+import { OctagonAlert } from "lucide-react";
 
 interface GitStatusCardProps {
   status: GitStatus;
@@ -22,8 +23,15 @@ export function GitStatusCard({ status, footer }: GitStatusCardProps) {
     <Card className="w-80">
       <CardHeader className="flex flex-row justify-between items-center">
         <CardTitle>Git Status</CardTitle>
-        <Badge variant={isDetached ? "destructive" : "default"}>
-          {isDetached ? "Detached HEAD" : "On Branch"}
+        <Badge variant="default">
+          {isDetached ? (
+            <span className="flex items-center gap-1">
+              <OctagonAlert className="w-4 h-4" />
+              Detached HEAD
+            </span>
+          ) : (
+            "On Branch"
+          )}
         </Badge>
       </CardHeader>
       <CardContent className="space-y-1">

--- a/frontend/src/components/git-status-card.tsx
+++ b/frontend/src/components/git-status-card.tsx
@@ -1,0 +1,42 @@
+import { isBranchMetadata, type GitStatus } from "@/client";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatGitRevision } from "@/types/nodes";
+
+interface GitStatusCardProps {
+  status: GitStatus;
+  footer?: (status: GitStatus) => React.ReactNode;
+}
+
+export function GitStatusCard({ status, footer }: GitStatusCardProps) {
+  const { revision } = status;
+  const isDetached = !isBranchMetadata(revision);
+
+  return (
+    <Card className="w-80">
+      <CardHeader className="flex flex-row justify-between items-center">
+        <CardTitle>Git Status</CardTitle>
+        <Badge variant={isDetached ? "destructive" : "default"}>
+          {isDetached ? "Detached HEAD" : "On Branch"}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        <div>
+          <div className="truncate font-semibold text-sm max-w-full overflow-hidden whitespace-nowrap">
+            {formatGitRevision(revision)}
+          </div>
+        </div>
+        <div className="text-muted-foreground text-sm">{revision.summary}</div>
+      </CardContent>
+      {footer && (
+        <CardFooter className="flex gap-2">{footer(status)}</CardFooter>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/sliding-panel.tsx
+++ b/frontend/src/components/sliding-panel.tsx
@@ -16,6 +16,7 @@ export const SlidingPanel: React.FC<SlidingPanelProps> = ({
   const panelRef = React.useRef<HTMLDivElement>(null);
 
   if (!isOpen) return null;
+
   return (
     <div
       onClick={(e) => {
@@ -23,11 +24,11 @@ export const SlidingPanel: React.FC<SlidingPanelProps> = ({
           onClose();
         }
       }}
-      className="bg-muted/30 fixed inset-0 z-40 backdrop-blur-sm justify-end"
+      className="bg-muted/30 fixed inset-0 z-40 backdrop-blur-sm justify-start" // ⬅️ Aligns content to the left
     >
       <div
         ref={panelRef}
-        className="fixed top-0 right-0 h-full p-4 fit-content bg-muted shadow-lg z-50"
+        className="fixed top-0 left-0 h-full p-4 fit-content bg-muted shadow-lg z-50" // ⬅️ Aligned to the left
       >
         <div className="flex justify-end items-center m-4">
           <button onClick={onClose} aria-label="Close">

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -158,8 +158,12 @@ export const useStore = create<AppState>()(
         set({ gitRevisions: [] });
       },
       async checkoutGitRevision(rev: string) {
+        let prevGitStatus = get().prevGitStatus;
+
         try {
-          const prevGitStatus = await fetchStatus();
+          if (!prevGitStatus) {
+            prevGitStatus = await fetchStatus();
+          }
           await checkoutRevision(rev);
           const gitStatus = await fetchStatus();
           toast.success(`Checked out revision ${rev}`);

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -10,7 +10,7 @@ import log from "loglevel";
 import { toast } from "sonner";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { checkoutRevision, client } from "./client";
+import { checkoutRevision, client, fetchStatus } from "./client";
 import {
   getMatchingMetaData,
   isAppNode,
@@ -95,6 +95,8 @@ const initialState = {
   hasUnsavedChanges: false,
   dialogNodeData: null,
   gitRevisions: [],
+  gitStatus: null,
+  prevGitStatus: null,
 };
 
 const logger = log.getLogger("store");
@@ -157,13 +159,39 @@ export const useStore = create<AppState>()(
       },
       async checkoutGitRevision(rev: string) {
         try {
+          const prevGitStatus = await fetchStatus();
+          await checkoutRevision(rev);
+          const gitStatus = await fetchStatus();
+          toast.success(`Checked out revision ${rev}`);
+          set({
+            prevGitStatus,
+            gitStatus,
+          });
+        } catch (e: unknown) {
+          toast.error(`Error checking out revision ${rev}`, {
+            description: (e as Error).message,
+          });
+        }
+      },
+      async restoreGitStatus() {
+        const rev = get().prevGitStatus?.revision.rev;
+        if (!rev) {
+          return;
+        }
+
+        try {
           await checkoutRevision(rev);
           toast.success(`Checked out revision ${rev}`);
         } catch (e: unknown) {
           toast.error(`Error checking out revision ${rev}`, {
             description: (e as Error).message,
           });
+          return;
         }
+        set({
+          prevGitStatus: null,
+          gitStatus: null,
+        });
       },
       createFlow: async (name: string) => {
         const { data, error } = await client.POST("/api/v1/flows", {

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -158,12 +158,8 @@ export const useStore = create<AppState>()(
         set({ gitRevisions: [] });
       },
       async checkoutGitRevision(rev: string) {
-        let prevGitStatus = get().prevGitStatus;
-
         try {
-          if (!prevGitStatus) {
-            prevGitStatus = await fetchStatus();
-          }
+          const prevGitStatus = get().prevGitStatus ?? (await fetchStatus());
           await checkoutRevision(rev);
           const gitStatus = await fetchStatus();
           toast.success(`Checked out revision ${rev}`);

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -10,7 +10,7 @@ import log from "loglevel";
 import { toast } from "sonner";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { client } from "./client";
+import { checkoutRevision, client } from "./client";
 import {
   getMatchingMetaData,
   isAppNode,
@@ -154,6 +154,16 @@ export const useStore = create<AppState>()(
       },
       clearGitRevisions() {
         set({ gitRevisions: [] });
+      },
+      async checkoutGitRevision(rev: string) {
+        try {
+          await checkoutRevision(rev);
+          toast.success(`Checked out revision ${rev}`);
+        } catch (e: unknown) {
+          toast.error(`Error checking out revision ${rev}`, {
+            description: (e as Error).message,
+          });
+        }
       },
       createFlow: async (name: string) => {
         const { data, error } = await client.POST("/api/v1/flows", {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -126,6 +126,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/git/repository/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get repository status
+         * @description Get the current status of the repository, including the current HEAD commit and branch.
+         */
+        get: operations["get_repository_status"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/git/tags": {
         parameters: {
             query?: never;
@@ -260,6 +280,12 @@ export interface components {
             edges: unknown[];
             /** @description Nodes of the reactflow state, the types of the nodes are managed on the frontend */
             nodes: unknown[];
+        };
+        RepositoryStatusResponse: {
+            /** @description The current branch name, not set if in a detached HEAD state */
+            currentBranch?: string | null;
+            /** @description The current HEAD commit */
+            head: components["schemas"]["Commit"];
         };
         Signature: {
             email: string;
@@ -649,6 +675,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ListCommitsResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiStatusDetailResponse"];
+                };
+            };
+        };
+    };
+    get_repository_status: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Repository status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepositoryStatusResponse"];
                 };
             };
             /** @description Internal server error */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -94,7 +94,12 @@ export interface paths {
          */
         get: operations["get_revision"];
         put?: never;
-        post?: never;
+        /**
+         * Checkout commit for a revision
+         * @description Checkout a commit by its revision.
+         *         The revision can be anything accepted by `git rev-parse`. For a branch it will checkout the HEAD of the branch.
+         */
+        post: operations["checkout_revision"];
         delete?: never;
         options?: never;
         head?: never;
@@ -554,6 +559,52 @@ export interface operations {
                 };
             };
             /** @description Commit not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiStatusDetailResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiStatusDetailResponse"];
+                };
+            };
+        };
+    };
+    checkout_revision: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description The revision of the commit to checkout.
+                 *
+                 *     This can be the short hash, full hash, a tag, or any other reference such as `HEAD`, a branch name or a tag name
+                 * @example HEAD
+                 */
+                revision: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Revision checked out successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Commit"];
+                };
+            };
+            /** @description Revision not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/types/state.ts
+++ b/frontend/src/types/state.ts
@@ -63,6 +63,8 @@ export interface AppState {
   addGitRevision: (rev: string) => void;
   /** Clear the Git revisions array */
   clearGitRevisions: () => void;
+  /** Checkout a git reivision */
+  checkoutGitRevision: (rev: string) => Promise<void>;
   /**
    * Create a flow on the server through the API
    * @description After successful creation of the flow, it will call {@link setNodes}, {@link setEdges}

--- a/frontend/src/types/state.ts
+++ b/frontend/src/types/state.ts
@@ -1,3 +1,4 @@
+import type { GitStatus } from "@/client";
 import {
   type Edge,
   type OnConnect,
@@ -63,8 +64,15 @@ export interface AppState {
   addGitRevision: (rev: string) => void;
   /** Clear the Git revisions array */
   clearGitRevisions: () => void;
-  /** Checkout a git reivision */
+  /** The current Git status of the repository */
+  gitStatus: GitStatus | null;
+  /** The Git status of the repository before the checkout*/
+  prevGitStatus: GitStatus | null;
+  /** Checkout a git revision, save back the current state */
   checkoutGitRevision: (rev: string) => Promise<void>;
+  /** Restore the original git status before a checkout */
+  restoreGitStatus: () => Promise<void>;
+
   /**
    * Create a flow on the server through the API
    * @description After successful creation of the flow, it will call {@link setNodes}, {@link setEdges}


### PR DESCRIPTION
- Added Backend API to checkout revisions and to get the current status (so far: current revision and branch name)
- Frontend:
  - UI Button to checkout the revision added to a node
  - Panel with card showing the current status (explicitly highlighting detached head mode)
  

https://github.com/user-attachments/assets/086d0cd1-5956-431e-bcfc-b2c823a01ebd

 Currently the state is not restored when closing the App, should we also add that?