### PR TITLE
Implement Git status SSE updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -395,6 +395,12 @@ dependencies = [
  "syn",
  "which",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -649,16 +655,20 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "futures-util",
  "git2-ox",
  "hannibal",
  "log",
  "mime_guess",
+ "notify",
+ "notify-debouncer-mini",
  "open",
  "rust-embed",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "utoipa",
  "utoipa-axum",
@@ -790,6 +800,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -944,7 +963,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1360,12 +1379,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -1452,6 +1491,26 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1630,6 +1689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -1643,6 +1703,42 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.9.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-traits"
@@ -1925,7 +2021,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2031,7 +2127,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2044,7 +2140,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2141,7 +2237,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2435,6 +2531,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +2605,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3061,7 +3169,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/backend/app/Cargo.toml
+++ b/backend/app/Cargo.toml
@@ -29,3 +29,10 @@ chrono = { version = "^0.4.41", features = ["serde"] }
 hannibal = "^0.12"
 axum-extra = { version = "0.10.1", features = ["query"] }
 open = "5.3"
+notify-debouncer-mini = "0.7.0"
+notify = "8.2.0"
+tokio-stream = { version = "0.1.17", features = ["sync"] }
+futures-util = { version = "0.3.31", default-features = false, features = [
+    "std",
+    "sink",
+] }

--- a/backend/app/src/fswatcher.rs
+++ b/backend/app/src/fswatcher.rs
@@ -1,0 +1,38 @@
+use notify::{RecursiveMode, Watcher};
+use notify_debouncer_mini::{DebouncedEvent, Debouncer, new_debouncer};
+use std::{sync::mpsc, time::Duration};
+
+/// Create a debouncer and return (debouncer, rx).
+/// Caller is responsible for running the blocking loop (e.g. in spawn_blocking).
+pub fn setup_watchers<P: AsRef<std::path::Path>>(
+    paths: &[P],
+    delay: Duration,
+) -> (Debouncer<impl Watcher>, mpsc::Receiver<Vec<DebouncedEvent>>) {
+    let (tx, rx) = mpsc::channel();
+
+    let mut debouncer = new_debouncer(
+        delay,
+        move |res: Result<Vec<DebouncedEvent>, notify::Error>| match res {
+            Ok(evs) => {
+                log::info!("Changes detected in watched paths");
+                let _ = tx.send(evs);
+            }
+            Err(e) => {
+                log::warn!("received notify error: {e:?}");
+            }
+        },
+    )
+    .expect("failed to create debouncer");
+
+    // Register all paths
+    for path in paths {
+        if let Err(e) = debouncer
+            .watcher()
+            .watch(path.as_ref(), RecursiveMode::Recursive)
+        {
+            eprintln!("watch error for {:?}: {:?}", path.as_ref(), e);
+        }
+    }
+
+    (debouncer, rx)
+}

--- a/backend/app/src/fswatcher.rs
+++ b/backend/app/src/fswatcher.rs
@@ -14,7 +14,7 @@ pub fn setup_watchers<P: AsRef<std::path::Path>>(
         delay,
         move |res: Result<Vec<DebouncedEvent>, notify::Error>| match res {
             Ok(evs) => {
-                log::info!("Changes detected in watched paths");
+                log::debug!("Detected changes in watched paths");
                 let _ = tx.send(evs);
             }
             Err(e) => {

--- a/backend/app/src/lib.rs
+++ b/backend/app/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actors;
 pub mod flow;
+mod fswatcher;
 pub mod utils;
 pub mod web;

--- a/backend/app/src/web.rs
+++ b/backend/app/src/web.rs
@@ -1,4 +1,4 @@
-use crate::{actors, flow};
+use crate::{actors, flow, fswatcher};
 use axum::routing;
 #[cfg(not(debug_assertions))]
 use axum::{http, response::IntoResponse};
@@ -7,6 +7,7 @@ use axum_reverse_proxy::ReverseProxy;
 use hannibal::prelude::*;
 #[cfg(not(debug_assertions))]
 use mime_guess::from_path;
+use tokio::sync::broadcast;
 use utoipa::OpenApi;
 
 #[cfg(not(debug_assertions))]
@@ -34,6 +35,7 @@ pub struct ApiDoc;
 struct AppState {
     flows_dir: flow::FlowsDir,
     git_actor: actors::git::GitActorAddr,
+    git_status_tx: broadcast::Sender<git2_ox::Status>,
 }
 
 impl AppState {
@@ -41,10 +43,17 @@ impl AppState {
         let repo = flows_dir.git_repo();
         let git_actor = crate::actors::git::GitActor::try_from_path(repo)?.spawn();
 
+        let (tx, _rx) = broadcast::channel(16);
+
         Ok(Self {
             flows_dir,
             git_actor,
+            git_status_tx: tx,
         })
+    }
+
+    pub fn repo_root_path(&self) -> &std::path::Path {
+        self.flows_dir.path().parent().unwrap()
     }
 
     pub fn flows_dir(&self) -> &flow::FlowsDir {
@@ -53,6 +62,11 @@ impl AppState {
 
     pub fn git_actor(&self) -> &actors::git::GitActorAddr {
         &self.git_actor
+    }
+
+    /// Sender for the broadcast channel sending Git status updates
+    pub fn git_status_tx(&self) -> &broadcast::Sender<git2_ox::Status> {
+        &self.git_status_tx
     }
 }
 
@@ -95,10 +109,12 @@ where
 {
     let app_state = AppState::try_new(flows_dir)?;
 
+    let repo_root = app_state.repo_root_path().to_path_buf();
+
     let rapidoc_path = "/api-docs";
     let app = routing::Router::new()
         .nest("/api", api::router())
-        .with_state(app_state)
+        .with_state(app_state.clone())
         .merge(
             utoipa_rapidoc::RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi())
                 .path(rapidoc_path),
@@ -118,6 +134,30 @@ where
         rapidoc_path
     );
     on_bind();
+
+    let paths = [repo_root.as_path()];
+
+    // TODO: Do we need to move the debouncer to another thread?
+    let (_debouncer, fs_rx) = fswatcher::setup_watchers(&paths, std::time::Duration::from_secs(1));
+
+    tokio::spawn(async move {
+        loop {
+            let res = fs_rx.recv();
+            match res {
+                Ok(_) => {
+                    // We get multiple events but don't care at all, we only need to get one Git status
+                    let actor = app_state.git_actor();
+                    let msg = actors::git::GetRepositoryStatus;
+                    let status = actor.call(msg).await.unwrap().unwrap();
+                    let _ = app_state.git_status_tx().send(status);
+                }
+                Err(errs) => {
+                    log::error!("watch error: {errs:?}")
+                }
+            }
+        }
+    });
+
     axum::serve(listener, app)
         // .with_graceful_shutdown(shutdown_signal(deletion_task.abort_handle()))
         .await?;

--- a/backend/git2-ox/src/commit.rs
+++ b/backend/git2-ox/src/commit.rs
@@ -11,7 +11,7 @@ pub trait CommitProperties {
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
 struct Signature {
     name: String,
@@ -43,8 +43,7 @@ impl From<Git2Time> for chrono::DateTime<chrono::Utc> {
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Commit {
     id: String,
     summary: String,
@@ -105,7 +104,7 @@ impl<'repo> Commit {
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
 pub struct CommitWithReferences {
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/backend/git2-ox/src/lib.rs
+++ b/backend/git2-ox/src/lib.rs
@@ -4,6 +4,7 @@ pub mod diff;
 pub mod error;
 pub mod reference;
 pub mod repository;
+pub mod status;
 pub mod tag;
 pub mod utils;
 
@@ -12,6 +13,7 @@ pub use commit::{Commit, CommitProperties, CommitWithReferences};
 pub use diff::Diff;
 pub use reference::{ReferenceKind, ReferenceMetadata, ResolvedReference};
 pub use repository::{ReferenceKindFilter, Repository};
+pub use status::Status;
 pub use tag::TaggedCommit;
 
 type Result<T> = std::result::Result<T, error::Error>;

--- a/backend/git2-ox/src/reference.rs
+++ b/backend/git2-ox/src/reference.rs
@@ -49,8 +49,7 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for ReferenceKind {
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ReferenceMetadata {
     name: String,
     kind: ReferenceKind,

--- a/backend/git2-ox/src/reference.rs
+++ b/backend/git2-ox/src/reference.rs
@@ -181,6 +181,11 @@ impl TryFrom<&git2::Repository> for ReferencesMap {
             let reference =
                 reference.map_err(|e| Error::from_ctx_and_error("Failed to get reference", e))?;
 
+            if reference.name() == Some("refs/stash") {
+                // Manually ignore stash reference
+                continue;
+            }
+
             if let Err(e) = ref_map.try_insert_reference(&reference) {
                 log::error!(
                     "Error adding reference to reference map {}: {}",

--- a/backend/git2-ox/src/repository.rs
+++ b/backend/git2-ox/src/repository.rs
@@ -224,7 +224,7 @@ impl Repository {
 
     /// Get the status of the repository
     pub fn status(&self) -> Result<Status> {
-        self.try_into()
+        Status::try_from_repository(self)
     }
 
     /// Add all paths matching the pathspecs to the index

--- a/backend/git2-ox/src/status.rs
+++ b/backend/git2-ox/src/status.rs
@@ -1,0 +1,175 @@
+use crate::{CommitWithReferences, Repository, Result, error::Error};
+
+type Files = Vec<String>;
+
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    serde(rename_all = "camelCase")
+)]
+#[derive(Default, Debug)]
+pub struct TreeStatus {
+    /// Added files
+    new_files: Files,
+    /// Modified files
+    modified_files: Files,
+    /// Deleted files
+    deleted_files: Files,
+    /// Renamed files
+    renamed_files: Files,
+}
+
+impl TreeStatus {
+    /// Files that were added
+    pub fn new_files(&self) -> &Files {
+        &self.new_files
+    }
+
+    /// Files that were modified
+    pub fn modified_files(&self) -> &Files {
+        &self.modified_files
+    }
+
+    /// Files that were deleted
+    pub fn deleted_files(&self) -> &Files {
+        &self.deleted_files
+    }
+
+    /// Files that were renamed
+    pub fn renamed_files(&self) -> &Files {
+        &self.renamed_files
+    }
+}
+
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    serde(rename_all = "camelCase")
+)]
+#[derive(Debug)]
+pub struct Status {
+    /// Name of the current branch, not set if `is_detached_head` is true
+    current_branch: Option<String>,
+    /// The commit current HEAD points to
+    head: CommitWithReferences,
+    /// Whether the head is detached
+    is_detached_head: bool,
+    /// Whether the worktree or index have changes
+    is_dirty: bool,
+    /// Status of the index
+    index: TreeStatus,
+    /// Status in the worktree
+    worktree: TreeStatus,
+    /// Paths with conflicts
+    conflicts: Files,
+}
+
+impl Status {
+    pub fn head(&self) -> &CommitWithReferences {
+        &self.head
+    }
+
+    pub fn is_detached_head(&self) -> bool {
+        self.is_detached_head
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.is_dirty
+    }
+
+    pub fn index(&self) -> &TreeStatus {
+        &self.index
+    }
+
+    pub fn worktree(&self) -> &TreeStatus {
+        &self.worktree
+    }
+
+    pub fn conflicted(&self) -> &Files {
+        &self.conflicts
+    }
+}
+
+impl TryFrom<&Repository> for Status {
+    type Error = Error;
+
+    fn try_from(repo: &Repository) -> Result<Self> {
+        let head = repo.get_commit_for_revision("HEAD")?;
+
+        let mut opts = git2::StatusOptions::new();
+        opts.include_untracked(true)
+            .recurse_untracked_dirs(true)
+            .include_ignored(false)
+            .renames_head_to_index(true)
+            .renames_index_to_workdir(true);
+
+        let statuses = repo
+            .repo()
+            .statuses(Some(&mut opts))
+            .map_err(|e| Error::from_ctx_and_error("Failed to create statuses", e))?;
+
+        let mut index_status = TreeStatus::default();
+        let mut worktree_status = TreeStatus::default();
+        let mut conflicts = Vec::new();
+
+        for entry in statuses.iter() {
+            let status = entry.status();
+            if status.is_index_new() {
+                index_status
+                    .new_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_index_renamed() {
+                index_status
+                    .renamed_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_index_modified() {
+                index_status
+                    .modified_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_index_deleted() {
+                index_status
+                    .deleted_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_wt_new() {
+                worktree_status
+                    .new_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_wt_renamed() {
+                worktree_status
+                    .renamed_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_wt_modified() {
+                worktree_status
+                    .modified_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_wt_deleted() {
+                worktree_status
+                    .deleted_files
+                    .push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            } else if status.is_conflicted() {
+                conflicts.push(entry.path().unwrap_or("<invalid utf-8>").to_string());
+            }
+        }
+
+        Ok(Self {
+            current_branch: repo.current_branch_name(),
+            head,
+            is_detached_head: repo.repo().head_detached().map_err(|e| {
+                Error::from_ctx_and_error("Failed to determined if head is detached", e)
+            })?,
+            is_dirty: !statuses.is_empty(),
+            index: index_status,
+            worktree: worktree_status,
+            conflicts,
+        })
+    }
+}
+
+impl TryFrom<Repository> for Status {
+    type Error = Error;
+    fn try_from(repo: Repository) -> Result<Self> {
+        Status::try_from(&repo)
+    }
+}

--- a/backend/git2-ox/src/status.rs
+++ b/backend/git2-ox/src/status.rs
@@ -8,7 +8,7 @@ type Files = Vec<String>;
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct TreeStatus {
     /// Added files
     new_files: Files,
@@ -48,7 +48,7 @@ impl TreeStatus {
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Status {
     /// Name of the current branch, not set if `is_detached_head` is true
     current_branch: Option<String>,

--- a/backend/git2-ox/src/status.rs
+++ b/backend/git2-ox/src/status.rs
@@ -8,7 +8,7 @@ type Files = Vec<String>;
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TreeStatus {
     /// Added files
     new_files: Files,
@@ -48,7 +48,7 @@ impl TreeStatus {
     derive(serde::Serialize),
     serde(rename_all = "camelCase")
 )]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Status {
     /// Name of the current branch, not set if `is_detached_head` is true
     current_branch: Option<String>,

--- a/backend/git2-ox/tests/common/mod.rs
+++ b/backend/git2-ox/tests/common/mod.rs
@@ -24,10 +24,15 @@ impl TempRepository {
         self.temp_dir.path()
     }
 
-    pub fn create_and_commit_random_file(&self) -> (FileName, CommitId) {
+    pub fn create_random_file(&self) -> FileName {
         let file_name = Uuid::new_v4().to_string();
         let file_path = self.path().join(&file_name);
         std::fs::write(&file_path, "random content").unwrap();
+        file_name
+    }
+
+    pub fn create_and_commit_random_file(&self) -> (FileName, CommitId) {
+        let file_name = self.create_random_file();
 
         let mut index = self.repo.repo().index().unwrap();
         index.add_path(std::path::Path::new(&file_name)).unwrap();

--- a/backend/git2-ox/tests/test_git_status.rs
+++ b/backend/git2-ox/tests/test_git_status.rs
@@ -1,0 +1,139 @@
+use std::io::Write;
+
+use git2_ox::utils;
+
+mod common;
+
+#[test]
+fn test_clean() {
+    let t = common::TempRepository::try_init().unwrap();
+    t.create_and_commit_random_file();
+    let status = t.repo().status().unwrap();
+    assert!(!status.is_dirty());
+}
+
+#[test]
+fn test_worktree_new() {
+    let t = common::TempRepository::try_init().unwrap();
+    t.create_and_commit_random_file();
+
+    let f = t.create_random_file();
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.worktree().new_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_worktree_modified() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (f, _) = t.create_and_commit_random_file();
+
+    let path = t.path().join(&f);
+    {
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(b"new content").unwrap();
+        file.sync_all().unwrap();
+    }
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.worktree().modified_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_worktree_renamed() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (f, _) = t.create_and_commit_random_file();
+
+    let new_filename = "new-filename";
+    std::fs::rename(t.path().join(&f), t.path().join(new_filename)).unwrap();
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.worktree().renamed_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_worktree_deleted() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (f, _) = t.create_and_commit_random_file();
+
+    std::fs::remove_file(t.path().join(&f)).unwrap();
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.worktree().deleted_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_index_new() {
+    let t = common::TempRepository::try_init().unwrap();
+    t.create_and_commit_random_file();
+
+    let f = t.create_random_file();
+    t.repo().add_all(["*"]).unwrap();
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.index().new_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_index_modified() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (f, _) = t.create_and_commit_random_file();
+
+    let path = t.path().join(&f);
+    {
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(b"new content").unwrap();
+        file.sync_all().unwrap();
+    }
+    t.repo().add_all(["*"]).unwrap();
+
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.index().modified_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_index_renamed() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (f, _) = t.create_and_commit_random_file();
+
+    let new_filename = "new-filename";
+    std::fs::rename(t.path().join(&f), t.path().join(new_filename)).unwrap();
+
+    t.repo().add_all(["*"]).unwrap();
+
+    let status = t.repo().status().unwrap();
+    dbg!(&status);
+    assert!(status.is_dirty());
+    assert_eq!(status.index().renamed_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_index_deleted() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (f, _) = t.create_and_commit_random_file();
+
+    std::fs::remove_file(t.path().join(&f)).unwrap();
+    t.repo().add_all(["*"]).unwrap();
+
+    let status = t.repo().status().unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.index().deleted_files().as_ref(), vec![f])
+}
+
+#[test]
+fn test_detached_head() {
+    let t = common::TempRepository::try_init().unwrap();
+    let (_, commit_id) = t.create_and_commit_random_file();
+    t.create_and_commit_random_file();
+    t.repo()
+        .repo()
+        .set_head_detached(
+            utils::get_commit_for_revision(t.repo().repo(), &commit_id)
+                .unwrap()
+                .id(),
+        )
+        .unwrap();
+    let status = t.repo().status().unwrap();
+    assert!(status.is_detached_head());
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { GitDialog } from "./components/git-dialog";
 import { GitRevisionsPanel } from "./components/git-revisions-panel";
 import { HelpDialog, KeybindingsDialog } from "./components/help-dialog";
 import { ActionNode, StatusNode } from "./components/nodes";
+import { StatusBar } from "./components/status-bar";
 import { Toaster } from "./components/ui/sonner";
 import { keybindings } from "./keybindings";
 import { isApple } from "./lib/utils";
@@ -228,6 +229,9 @@ export const App = () => {
         <CreateNodeDialog />
         <GitDialog />
         <GitRevisionsPanel />
+        <Panel position="bottom-left">
+          <StatusBar />
+        </Panel>
       </ReactFlow>
       <Toaster
         position="bottom-right"

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -252,15 +252,21 @@ export async function createTag(
   };
 }
 
-export interface GitStatus {
-  /** current checked out branch/ commit (detached HEAD) */
-  revision: BranchMetadata | CommitMetadata;
-}
-export async function fetchStatus(): Promise<GitStatus> {
+export const fetchRepositoryStatus = async () => {
   const { data, error } = await client.GET("/api/v1/git/repository/status", {});
   if (error) {
     throw new ApiError(error, "Error fetching Git status");
   }
+  return data;
+};
+
+export interface GitStatus {
+  /** current checked out branch/ commit (detached HEAD) */
+  revision: BranchMetadata | CommitMetadata;
+}
+
+export async function fetchStatus(): Promise<GitStatus> {
+  const data = await fetchRepositoryStatus();
 
   let revision;
   if (data.currentBranch) {

--- a/frontend/src/components/action-button.tsx
+++ b/frontend/src/components/action-button.tsx
@@ -1,4 +1,4 @@
-import { copyToClipboard } from "@/lib/utils";
+import { cn, copyToClipboard } from "@/lib/utils";
 import { Check, Copy } from "lucide-react";
 import React from "react";
 import { Button } from "./ui/button";
@@ -94,12 +94,17 @@ interface CopyButtonProps {
   value: string;
   /** Whether to show a tooltip */
   tooltip?: boolean | string;
+  className?: string;
 }
 
-export const CopyButton = ({ value, tooltip = true }: CopyButtonProps) => {
+export const CopyButton = ({
+  value,
+  tooltip = true,
+  className = undefined,
+}: CopyButtonProps) => {
   return (
     <ActionButton
-      className="size-6"
+      className={cn("size-6", className)}
       tooltipContent={
         tooltip === true
           ? "Copy to clipboard"

--- a/frontend/src/components/status-bar.tsx
+++ b/frontend/src/components/status-bar.tsx
@@ -1,0 +1,347 @@
+import { fetchRepositoryStatus } from "@/client";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { ApiError } from "@/lib/errors";
+import { notify } from "@/lib/notify";
+import { cn } from "@/lib/utils";
+import { useStore, useUiStore } from "@/store";
+import type { RepositoryStatus } from "@/types/api-types";
+import { formatGitRevision } from "@/types/nodes";
+import type { AppState, UiState } from "@/types/state";
+import {
+  FileDiff,
+  FileInput,
+  FileMinus,
+  FilePlus,
+  GitBranch,
+  GitCommitVertical,
+  GitGraph,
+  Pin,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import React from "react";
+import { useShallow } from "zustand/react/shallow";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+
+const StatusBarItem = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => {
+  return (
+    <div
+      className={cn(
+        "flex items-center items-center gap-1 px-2 h-full",
+        "[&>svg]:w-3 [&>svg]:h-3 text-sm",
+        // "[&>svg]:w-3 [&>svg]:h-3 text-xs",
+        className,
+      )}
+      {...props}
+    ></div>
+  );
+};
+
+const BranchStatusBarItem = React.memo(
+  ({ status }: { status: RepositoryStatus }) => {
+    if (status.isDetachedHead) {
+      return (
+        // TODO: Allow checking out a branch on the commit
+        <StatusBarItem>
+          <GitCommitVertical /> {status.head.id.slice(0, 7)}
+        </StatusBarItem>
+      );
+    }
+    // TODO: Allow creating a branch/tag or switching branch
+
+    return (
+      <StatusBarItem>
+        <GitBranch /> {status.currentBranch}
+      </StatusBarItem>
+    );
+  },
+);
+
+const GitStatusFileList = ({
+  paths,
+  icon,
+  className,
+  ...props
+}: {
+  paths: string[];
+  icon: LucideIcon;
+} & React.ComponentProps<"div">) => {
+  const Icon = icon;
+  return (
+    <>
+      {paths.map((path) => {
+        return (
+          <div
+            className={cn(
+              "flex gap-1 font-mono text-sm items-center pl-1",
+              className,
+            )}
+            {...props}
+          >
+            <Icon size={14} className="shrink-0" /> {path}
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+const ChangesStatusBarItem = React.memo(
+  ({ status }: { status: RepositoryStatus }) => {
+    const added =
+      status.index.newFiles.length + status.worktree.newFiles.length;
+    const modified =
+      status.index.modifiedFiles.length + status.worktree.modifiedFiles.length;
+    const renamed =
+      status.index.renamedFiles.length + status.worktree.renamedFiles.length;
+    const deleted =
+      status.index.deletedFiles.length + status.worktree.deletedFiles.length;
+
+    const indexChanges =
+      status.index.newFiles.length +
+      status.index.modifiedFiles.length +
+      status.index.renamedFiles.length +
+      status.index.deletedFiles.length;
+    const worktreeChanges =
+      status.worktree.newFiles.length +
+      status.worktree.modifiedFiles.length +
+      status.worktree.renamedFiles.length +
+      status.worktree.deletedFiles.length;
+    if (added + deleted + renamed + modified === 0) {
+      return null;
+    }
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <StatusBarItem>
+            {added > 0 && (
+              <>
+                <FilePlus /> {added}
+              </>
+            )}
+            {deleted > 0 && (
+              <>
+                <FileMinus /> {deleted}
+              </>
+            )}
+            {renamed > 0 && (
+              <>
+                <FileInput />
+                {renamed}
+              </>
+            )}
+            {modified > 0 && (
+              <>
+                <FileDiff /> {modified}
+              </>
+            )}
+          </StatusBarItem>
+        </PopoverTrigger>
+        <PopoverContent className="w-fit space-y-1">
+          {indexChanges > 0 && (
+            <>
+              <h4 className="font-medium">Index</h4>
+              <div className="text-emerald-600">
+                <GitStatusFileList
+                  paths={status.index.newFiles}
+                  icon={FilePlus}
+                />
+                <GitStatusFileList
+                  paths={status.index.modifiedFiles}
+                  icon={FileDiff}
+                />
+                <GitStatusFileList
+                  paths={status.index.renamedFiles}
+                  icon={FileInput}
+                />
+                <GitStatusFileList
+                  paths={status.index.deletedFiles}
+                  icon={FileMinus}
+                />
+              </div>
+            </>
+          )}
+          {worktreeChanges > 0 && (
+            <>
+              <h4 className="font-medium">Worktree</h4>
+              <div className="text-red-600">
+                <GitStatusFileList
+                  paths={status.worktree.newFiles}
+                  icon={FilePlus}
+                />
+                <GitStatusFileList
+                  paths={status.worktree.modifiedFiles}
+                  icon={FileDiff}
+                />
+                <GitStatusFileList
+                  paths={status.worktree.renamedFiles}
+                  icon={FileInput}
+                />
+                <GitStatusFileList
+                  paths={status.worktree.deletedFiles}
+                  icon={FileMinus}
+                />
+              </div>
+            </>
+          )}
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
+
+const uiSelector = (s: UiState) => ({
+  setIsGitDialogOpen: s.setIsGitDialogOpen,
+});
+
+const selector = (state: AppState) => ({
+  pinnedGitRevisions: state.pinnedGitRevisions,
+  clearPinnedGitRevisions: state.clearPinnedGitRevisions,
+  gitStatus: state.gitStatus,
+  prevGitStatus: state.prevGitStatus,
+  restoreGitStatus: state.restoreGitStatus,
+  hasRevisions: state.pinnedGitRevisions[0] !== null,
+  displayPanel: state.pinnedGitRevisions[0] !== null || state.gitStatus != null,
+});
+
+const PinnedRevisionsStatusBarItem = () => {
+  const { pinnedGitRevisions, clearPinnedGitRevisions, hasRevisions } =
+    useStore(useShallow(selector));
+  const { setIsGitDialogOpen } = useUiStore(useShallow(uiSelector));
+
+  return (
+    <StatusBarItem>
+      <Popover>
+        <PopoverTrigger>
+          <>
+            <Pin />
+            {hasRevisions && (
+              <>
+                {pinnedGitRevisions.map(
+                  (rev, index) =>
+                    rev && (
+                      <div key={index} className="py-2 flex items-center">
+                        {formatGitRevision(rev)}
+                        {/* <CopyButton value={rev.rev} tooltip={false}  /> */}
+                      </div>
+                    ),
+                )}
+              </>
+            )}
+          </>
+        </PopoverTrigger>
+        <PopoverContent>
+          <div className="grid gap-4">
+            <div className="space-y-2">
+              <h4 className="leading-none font-medium">Pinned Git Revisions</h4>
+            </div>
+            <div className="grid gap-2">
+              <div className="grid grid-cols-3 items-center gap-4">
+                <Label htmlFor="base">Base</Label>
+                <Input
+                  id="width"
+                  defaultValue="100%"
+                  className="col-span-2 h-8"
+                />
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {hasRevisions && (
+        <>
+          <Button
+            disabled={pinnedGitRevisions[1] === null}
+            variant="destructive"
+            className="has-[>svg]:px-1"
+            onClick={() => {
+              clearPinnedGitRevisions();
+            }}
+          >
+            <X />
+          </Button>
+          <Button
+            disabled={pinnedGitRevisions[1] === null}
+            variant="secondary"
+            onClick={() => {
+              setIsGitDialogOpen(true);
+            }}
+          >
+            <GitGraph />
+          </Button>
+        </>
+      )}
+    </StatusBarItem>
+  );
+};
+
+export const StatusBar = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => {
+  const [repositoryStatus, setRepositoryStatus] =
+    React.useState<null | RepositoryStatus>(null);
+
+  React.useEffect(() => {
+    // First fetch the repository status when the component is mounted
+    fetchRepositoryStatus()
+      .then((data) => {
+        setRepositoryStatus(data);
+      })
+      .catch((err: ApiError) => {
+        notify.error(err.message);
+      });
+
+    // Register
+    const es = new EventSource("/api/v1/git/repository/status/stream");
+
+    es.addEventListener("git-status", (e) => {
+      const data = (e as MessageEvent).data;
+
+      console.log("sse event", data);
+      try {
+        const msg: RepositoryStatus = JSON.parse(data);
+        console.log("new repository status", msg);
+        setRepositoryStatus(msg); // prepend latest
+      } catch (err) {
+        console.error("Failed to parse SSE JSON:", err);
+      }
+    });
+
+    es.onerror = (err) => {
+      console.error("EventSource error:", err);
+    };
+
+    return () => {
+      es.close();
+    };
+  }, []);
+
+  if (repositoryStatus === null) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "bg-background flex h-9 items-center rounded-md border shadow-xs overflow-hidden cursor-default divide-solid divide-x",
+        className,
+      )}
+      {...props}
+    >
+      <BranchStatusBarItem status={repositoryStatus} />
+      <ChangesStatusBarItem status={repositoryStatus} />
+      {/* <PinnedRevisionsStatusBarItem /> */}
+    </div>
+  );
+};

--- a/frontend/src/components/status-bar.tsx
+++ b/frontend/src/components/status-bar.tsx
@@ -1,10 +1,8 @@
-import { fetchRepositoryStatus } from "@/client";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { notify } from "@/lib/notify";
 import { TypedEventSource } from "@/lib/sse";
 import { cn } from "@/lib/utils";
 import { useStore, useUiStore } from "@/store";
@@ -39,8 +37,8 @@ const StatusBarItem = ({
   return (
     <div
       className={cn(
-        "flex items-center items-center gap-1 px-2 h-full",
-        "[&>svg]:w-3 [&>svg]:h-3 text-sm",
+        "flex h-full items-center gap-1 px-2",
+        "text-sm [&>svg]:h-3 [&>svg]:w-3",
         // "[&>svg]:w-3 [&>svg]:h-3 text-xs",
         className,
       )}
@@ -85,7 +83,7 @@ const GitStatusFileList = ({
         return (
           <div
             className={cn(
-              "flex gap-1 font-mono text-sm items-center pl-1",
+              "flex items-center gap-1 pl-1 font-mono text-sm",
               className,
             )}
             {...props}
@@ -232,7 +230,7 @@ export const PinnedRevisionsStatusBarItem = () => {
                 {pinnedGitRevisions.map(
                   (rev, index) =>
                     rev && (
-                      <div key={index} className="py-2 flex items-center">
+                      <div key={index} className="flex items-center py-2">
                         {formatGitRevision(rev)}
                         {/* <CopyButton value={rev.rev} tooltip={false}  /> */}
                       </div>
@@ -301,14 +299,14 @@ export const StatusBar = ({
     React.useState<null | RepositoryStatus>(null);
 
   React.useEffect(() => {
-    // First fetch the repository status when the component is mounted
-    fetchRepositoryStatus()
-      .then((data) => {
-        setRepositoryStatus(data);
-      })
-      .catch((err: unknown) => {
-        notify.error(err);
-      });
+    // // First fetch the repository status when the component is mounted
+    // fetchRepositoryStatus()
+    //   .then((data) => {
+    //     setRepositoryStatus(data);
+    //   })
+    //   .catch((err: unknown) => {
+    //     notify.error(err);
+    //   });
 
     const es = new TypedEventSource<GitStatusEventMap>(
       "/api/v1/git/repository/status/stream",
@@ -336,7 +334,7 @@ export const StatusBar = ({
   return (
     <div
       className={cn(
-        "bg-background flex h-9 items-center rounded-md border shadow-xs overflow-hidden cursor-default divide-solid divide-x",
+        "bg-background flex h-9 cursor-default items-center divide-x divide-solid overflow-hidden rounded-md border shadow-xs",
         className,
       )}
       {...props}

--- a/frontend/src/hooks/use-event-stream.ts
+++ b/frontend/src/hooks/use-event-stream.ts
@@ -1,0 +1,135 @@
+import { ReconnectingTypedEventSource, TypedEventSource } from "@/lib/sse";
+import React from "react";
+
+interface UseEventStreamOptions extends EventSourceInit {
+  initialReconnectDelay?: number;
+  maxReconnectDelay?: number;
+  backoffFactor?: number;
+}
+
+/**
+ * React hook for consuming a server-sent events (SSE) stream with automatic reconnection.
+ *
+ * Wraps {@link ReconnectingTypedEventSource} and provides a declarative interface for subscribing
+ * to the latest event of a stream
+ *
+ * @template Events - A record type describing the event names and their payload types.
+ *
+ * @param {string} url - The SSE endpoint URL.
+ * @param {UseEventStreamOptions} [options] - Optional configuration for the connection and reconnection.
+ * @param {number} [options.initialReconnectDelay=1000] - Delay (ms) before the first reconnect attempt.
+ * @param {number} [options.maxReconnectDelay=30000] - Maximum backoff delay (ms) between reconnect attempts.
+ * @param {number} [options.backoffFactor=2] - Multiplier applied to the reconnect delay after each failure.
+ * @param {boolean} [options.withCredentials] - Whether the EventSource should send cookies/auth headers.
+ *
+ * @returns {{
+ *   connected: boolean;
+ *   events: { [K in keyof Events]: Events[K] | Events[K][] };
+ *   subscribe: <K extends keyof Events>(type: keyof Events) => void;
+ * }}
+ *
+ * Hook state and API:
+ *
+ * - `connected`: Whether the SSE connection is currently open.
+ * - `events`: An object mapping event names to their last event payload
+ * - `subscribe(type)`: Registers a handler for an event type
+ *
+ * @example
+ * type MyEvents = {
+ *   message: { text: string };
+ *   status: { online: boolean };
+ * };
+ *
+ * function Chat() {
+ *   const { connected, events, subscribe } = useEventStream<MyEvents>("/api/stream", {
+ *     withCredentials: true,
+ *   });
+ *
+ *   useEffect(() => {
+ *     subscribe("message"); // store all messages
+ *     subscribe("status");   // keep only latest status
+ *   }, [subscribe]);
+ *
+ *   return (
+ *     <div>
+ *       <p>Connected: {connected ? "✅" : "❌"}</p>
+ *       <ul>
+ *         {(events.message ?? []).map((msg, i) => (
+ *           <li key={i}>{msg.text}</li>
+ *         ))}
+ *       </ul>
+ *     </div>
+ *   );
+ * }
+ */
+export const useEventStream = <Events extends Record<string, unknown>>(
+  url: string,
+  reconnect = true,
+  options: UseEventStreamOptions = {},
+) => {
+  const sourceRef = React.useRef<
+    ReconnectingTypedEventSource<Events> | TypedEventSource<Events> | null
+  >(null);
+  const [isConnected, setIsConnected] = React.useState(false);
+
+  const [eventData, setEventData] = React.useState<
+    Partial<{ [K in keyof Events]: Events[K] }>
+  >({});
+
+  const {
+    initialReconnectDelay,
+    maxReconnectDelay,
+    backoffFactor,
+    withCredentials,
+  } = options;
+  // Memoize options to use in React.useEffect dependency array. If options was just added there and is an object
+  // literal created inline (e.g. { initialReconnectDelay: 2000 }), a new reference is created on every render,
+  // causing the effect to run on every render — defeating the point.
+  const memoOptions = React.useMemo(
+    () => ({
+      initialReconnectDelay,
+      maxReconnectDelay,
+      backoffFactor,
+      withCredentials,
+    }),
+    [initialReconnectDelay, maxReconnectDelay, backoffFactor, withCredentials],
+  );
+
+  React.useEffect(() => {
+    const stream = reconnect
+      ? new ReconnectingTypedEventSource<Events>(url, memoOptions)
+      : new TypedEventSource<Events>(url, memoOptions);
+    sourceRef.current = stream;
+
+    stream.onOpen(() => {
+      setIsConnected(true);
+    });
+    stream.onError(() => {
+      setIsConnected(false);
+    });
+
+    return () => {
+      stream.close();
+      sourceRef.current = null;
+      setIsConnected(false);
+    };
+  }, [url, memoOptions, reconnect]);
+
+  // subscribe to events and push data into state
+  const subscribe = React.useCallback((type: keyof Events) => {
+    if (!sourceRef.current) return;
+
+    sourceRef.current.on(type, (e) => {
+      setEventData((prev) => ({
+        ...prev,
+        [type]: e.data,
+      }));
+    });
+  }, []);
+
+  return {
+    isConnected,
+    events: eventData as { [K in keyof Events]: Events[K] | undefined },
+    subscribe,
+  };
+};

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -51,4 +51,141 @@ export class TypedEventSource<Events extends Record<string, unknown>> {
   close() {
     this.source.close();
   }
+
+  isConnecting() {
+    return this.source.readyState === this.source.CONNECTING;
+  }
+
+  isOpen() {
+    return this.source.readyState === this.source.OPEN;
+  }
+
+  isClosed() {
+    return this.source.readyState === this.source.CLOSED;
+  }
+}
+
+interface ReconnectOptions extends EventSourceInit {
+  /** Initial reconnect delay in ms (default: 1000) */
+  initialReconnectDelay?: number;
+  /** Maximum reconnect delay in ms (default: 30_000) */
+  maxReconnectDelay?: number;
+  /** Exponential backoff factor (default: 2) */
+  backoffFactor?: number;
+}
+
+type EventHandler<
+  Events extends Record<string, unknown>,
+  Type extends keyof Events,
+> = (event: MessageEvent<Events[Type]>) => void;
+
+type EventHandlerMap<E extends Record<string, unknown>> = {
+  [K in keyof E]?: EventHandler<E, K>[];
+};
+
+export class ReconnectingTypedEventSource<
+  Events extends Record<string, unknown>,
+> {
+  private url: string;
+  private options: ReconnectOptions;
+  private reconnectDelay: number;
+  private shouldReconnect = true;
+
+  private source: TypedEventSource<Events>;
+  private listeners: {
+    open: ((e: Event) => void)[];
+    error: ((e: Event) => void)[];
+    events: EventHandlerMap<Events>;
+  } = {
+    open: [],
+    error: [],
+    events: {},
+  };
+
+  constructor(url: string, options: ReconnectOptions = {}) {
+    this.url = url;
+    this.options = options;
+    this.reconnectDelay = options.initialReconnectDelay ?? 1000;
+    this.source = this.createSource();
+  }
+
+  private createSource(): TypedEventSource<Events> {
+    const src = new TypedEventSource<Events>(this.url, this.options);
+
+    // Re-attach listeners by iterating over the events object
+    for (const type in this.listeners.events) {
+      const handlers = this.listeners.events[type as keyof Events];
+      if (handlers) {
+        handlers.forEach((h) => {
+          src.on(
+            type,
+            h as (event: MessageEvent<Events[keyof Events]>) => void,
+          );
+        });
+      }
+    }
+
+    this.listeners.open.forEach((h) => {
+      src.onOpen(h);
+    });
+    this.listeners.error.forEach((h) => {
+      src.onError(h);
+    });
+
+    // add our reconnect logic
+    src.onError(() => {
+      _logger.error(
+        "Connection lost. Scheduling reconnect in",
+        this.reconnectDelay,
+        "ms",
+      );
+      this.scheduleReconnect();
+    });
+
+    return src;
+  }
+
+  private scheduleReconnect() {
+    if (!this.shouldReconnect) return;
+
+    this.source.close();
+
+    setTimeout(() => {
+      if (!this.shouldReconnect) return;
+      _logger.info("Reconnecting to", this.url);
+
+      this.source = this.createSource();
+
+      // exponential backoff
+      this.reconnectDelay = Math.min(
+        this.reconnectDelay * (this.options.backoffFactor ?? 2),
+        this.options.maxReconnectDelay ?? 30_000,
+      );
+    }, this.reconnectDelay);
+  }
+
+  on<K extends keyof Events>(type: K, listener: EventHandler<Events, K>) {
+    const listeners = this.listeners.events[type];
+    if (listeners) {
+      listeners.push(listener);
+    } else {
+      this.listeners.events[type] = [listener];
+    }
+    this.source.on(type, listener);
+  }
+
+  onOpen(listener: (event: Event) => void) {
+    this.listeners.open.push(listener);
+    this.source.onOpen(listener);
+  }
+
+  onError(listener: (event: Event) => void) {
+    this.listeners.error.push(listener);
+    this.source.onError(listener);
+  }
+
+  close() {
+    this.shouldReconnect = false;
+    this.source.close();
+  }
 }

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,0 +1,54 @@
+import log from "loglevel";
+
+const _logger = log.getLogger("sse");
+
+export class TypedEventSource<Events extends Record<string, unknown>> {
+  private source: EventSource;
+  /**
+   * Creates a new `TypedEventSource` instance.
+   * @param url The URL to connect to.
+   * @param options Optional `EventSourceInit` options.
+   */
+  constructor(url: string, options?: EventSourceInit) {
+    this.source = new EventSource(url, options);
+  }
+
+  /**
+   * Registers an event listener for a specific event type.
+   * @param type The type of event to listen for.
+   * @param listener The callback function to invoke when the event occurs.
+   */
+  on<K extends keyof Events>(
+    type: K,
+    listener: (event: MessageEvent<Events[K]>) => void,
+  ) {
+    this.source.addEventListener(type as string, (e) => {
+      const messageEvent = e as MessageEvent<string>;
+      let parsed: Events[K];
+      try {
+        parsed = JSON.parse(messageEvent.data) as Events[K];
+      } catch {
+        _logger.warn(
+          `Failed to parse event ${type.toString()}`,
+          messageEvent.data,
+        );
+        return;
+      }
+      listener(new MessageEvent(type as string, { data: parsed }));
+    });
+  }
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
+  onOpen(listener: (event: Event) => void) {
+    this.source.onopen = listener;
+  }
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
+  onError(listener: (event: Event) => void) {
+    this.source.onerror = listener;
+  }
+  /**
+   * Close the event source
+   */
+  close() {
+    this.source.close();
+  }
+}

--- a/frontend/src/types/api-types.ts
+++ b/frontend/src/types/api-types.ts
@@ -10,3 +10,4 @@ export type CommitWithReferences =
 export type ReferenceMetadata = components["schemas"]["ReferenceMetadata"];
 export type ReferenceType = components["schemas"]["ReferenceKind"];
 export type Diff = components["schemas"]["Diff"];
+export type RepositoryStatus = components["schemas"]["Status"];

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -342,12 +342,7 @@ export interface components {
             kind: components["schemas"]["ReferenceKind"];
             name: string;
         };
-        RepositoryStatusResponse: {
-            /** @description The current branch name, not set if in a detached HEAD state */
-            currentBranch?: string | null;
-            /** @description The current HEAD commit */
-            head: components["schemas"]["CommitWithReferences"];
-        };
+        RepositoryStatusResponse: components["schemas"]["Status"];
         ResolvedReference: components["schemas"]["ReferenceMetadata"] & {
             target: components["schemas"]["Commit"];
         };
@@ -355,12 +350,39 @@ export interface components {
             email: string;
             name: string;
         };
+        Status: {
+            /** @description Paths with conflicts */
+            conflicts: components["schemas"]["Vec"];
+            /** @description Name of the current branch, not set if `is_detached_head` is true */
+            currentBranch?: string | null;
+            /** @description The commit current HEAD points to */
+            head: components["schemas"]["CommitWithReferences"];
+            /** @description Status of the index */
+            index: components["schemas"]["TreeStatus"];
+            /** @description Whether the head is detached */
+            isDetachedHead: boolean;
+            /** @description Whether the worktree or index have changes */
+            isDirty: boolean;
+            /** @description Status in the worktree */
+            worktree: components["schemas"]["TreeStatus"];
+        };
         TaggedCommit: {
             /** @description Commit the tag is on */
             commit: components["schemas"]["Commit"];
             /** @description Tag on the commit */
             tag: string;
         };
+        TreeStatus: {
+            /** @description Deleted files */
+            deletedFiles: components["schemas"]["Vec"];
+            /** @description Modified files */
+            modifiedFiles: components["schemas"]["Vec"];
+            /** @description Added files */
+            newFiles: components["schemas"]["Vec"];
+            /** @description Renamed files */
+            renamedFiles: components["schemas"]["Vec"];
+        };
+        Vec: string[];
     };
     responses: never;
     parameters: never;


### PR DESCRIPTION
This PR contains multiple changes, related to the Git status.

* Update Git status API to contain more information
* Handler for SSE requests that sends a Git status as a first message
* Debounced file watcher on the repository sending updates through a `std::sync::mpsc::channel` 
* Receiver of the FS events in a tokio task that sends the current Git status through a `tokio::sync::broadcast::channel` to the individual event streams

On the client side there are also some changes:

* Added status bar component that shows the current branch and added/renamed/changed/deleted files, this can be extended to solve all Git operations (pin, checkout, ...) in the future
* Added Typesafe and reconnecting wrapper around the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) API - although we should evaluate if we switch to WebSockets in the future as SSE only supports 6 connections to one host per browser instance. Maybe this also does not matter as `debug-flow` would anyways fall apart with different flows in different tabs as the `zustand` stores would overwrite each other.
* Added `useEventStream` hook to declare subscription to an event type


Closes #102 